### PR TITLE
Add a diagnostics hook to instrument error checking

### DIFF
--- a/packages/typescript/src/typescript.ts
+++ b/packages/typescript/src/typescript.ts
@@ -9,15 +9,21 @@ import { error, info } from '@betterer/logger';
 const readFile = ts.sys.readFile.bind(ts.sys);
 const readDirectory = ts.sys.readDirectory.bind(ts.sys);
 
+type DiagnosticsHook = (
+  diagnostics: ts.SortedReadonlyArray<ts.Diagnostic>
+) => void;
+
 export function typescriptBetterer(
   configFilePath: string,
-  extraCompilerOptions?: ts.CompilerOptions
+  extraCompilerOptions?: ts.CompilerOptions,
+  diagnosticsHook?: DiagnosticsHook
 ): Betterer {
   const [, callee] = stack();
   const cwd = path.dirname(callee.getFileName());
   const absPath = path.resolve(cwd, configFilePath);
   return {
-    test: (): number => createTypescriptTest(absPath, extraCompilerOptions),
+    test: (): number =>
+      createTypescriptTest(absPath, extraCompilerOptions, diagnosticsHook),
     constraint: smaller,
     goal: 0
   };
@@ -25,7 +31,8 @@ export function typescriptBetterer(
 
 function createTypescriptTest(
   configFilePath: string,
-  extraCompilerOptions?: ts.CompilerOptions
+  extraCompilerOptions?: ts.CompilerOptions,
+  diagnosticsHook?: DiagnosticsHook
 ): number {
   info(`running TypeScript compiler...`);
 
@@ -72,8 +79,14 @@ function createTypescriptTest(
   ]);
 
   if (allDiagnostics.length) {
-    error('TypeScript compiler found some issues:');
-    console.log(ts.formatDiagnosticsWithColorAndContext(allDiagnostics, host));
+    if (diagnosticsHook) {
+      diagnosticsHook(allDiagnostics);
+    } else {
+      error('TypeScript compiler found some issues:');
+      console.log(
+        ts.formatDiagnosticsWithColorAndContext(allDiagnostics, host)
+      );
+    }
   }
   return allDiagnostics.length;
 }


### PR DESCRIPTION
As discussed in #4, this adds a mechanism to the typescript plugin to allow custom error reporting. 