### PR TITLE
(refactoring :hammer:) - rename stuff from Better to Betterer

### DIFF
--- a/packages/betterer/src/betterer.ts
+++ b/packages/betterer/src/betterer.ts
@@ -5,18 +5,18 @@ import { read } from './reader';
 import { serialise } from './serialiser';
 import {
   BettererConfig,
-  BetterResults,
-  BetterStats,
-  BetterTests
+  BettererResults,
+  BettererStats,
+  BettererTests
 } from './types';
 import { write } from './writer';
 
-export async function betterer(config: BettererConfig): Promise<BetterStats> {
+export async function betterer(config: BettererConfig): Promise<BettererStats> {
   setConfig(config);
   info('running betterer!');
 
   const { configPaths, filters, resultsPath } = config;
-  let tests: BetterTests = {};
+  let tests: BettererTests = {};
   await Promise.all(
     configPaths.map(async configPath => {
       const moreTests = await getTests(configPath);
@@ -30,7 +30,7 @@ export async function betterer(config: BettererConfig): Promise<BetterStats> {
     return filters.some(filter => filter.test(testName));
   });
 
-  let expectedResults: BetterResults = {};
+  let expectedResults: BettererResults = {};
   if (resultsPath) {
     try {
       expectedResults = await read(resultsPath);
@@ -47,7 +47,7 @@ export async function betterer(config: BettererConfig): Promise<BetterStats> {
     delete expectedResults[obsoleteName];
   });
 
-  const stats: BetterStats = {
+  const stats: BettererStats = {
     obsolete: obsoleteNames,
     ran: [],
     failed: [],
@@ -59,7 +59,7 @@ export async function betterer(config: BettererConfig): Promise<BetterStats> {
     completed: []
   };
 
-  const results: BetterResults = { ...expectedResults };
+  const results: BettererResults = { ...expectedResults };
 
   await testsToRun.reduce(async (p, testName) => {
     await p;
@@ -190,7 +190,7 @@ function getThings(count: number): string {
   return count === 1 ? 'thing' : 'things';
 }
 
-async function getTests(configPath: string): Promise<BetterTests> {
+async function getTests(configPath: string): Promise<BettererTests> {
   try {
     const imported = await import(configPath);
     return imported.default ? imported.default : imported;

--- a/packages/betterer/src/printer.ts
+++ b/packages/betterer/src/printer.ts
@@ -1,8 +1,8 @@
-import { BetterResults } from './types';
+import { BettererResults } from './types';
 
 const RESULTS_HEADER = `// BETTERER RESULTS V1.`;
 
-export function print(results: BetterResults): string {
+export function print(results: BettererResults): string {
   const printed = Object.keys(results).map(resultName => {
     const { timestamp, value } = results[resultName];
     return `\nexports[\`${resultName}\`] = { timestamp: ${timestamp}, value: \`${value}\` };`;

--- a/packages/betterer/src/reader.ts
+++ b/packages/betterer/src/reader.ts
@@ -1,11 +1,11 @@
 import { readFile } from 'fs';
 import { promisify } from 'util';
 
-import { BetterResults } from './types';
+import { BettererResults } from './types';
 
 const readFileAsync = promisify(readFile);
 
-export async function read(resultsPath: string): Promise<BetterResults> {
+export async function read(resultsPath: string): Promise<BettererResults> {
   try {
     await readFileAsync(resultsPath);
   } catch {

--- a/packages/betterer/src/types.ts
+++ b/packages/betterer/src/types.ts
@@ -1,16 +1,16 @@
-type BetterTest<T = unknown> = () => T | Promise<T>;
-type BetterConstraint<T = unknown> = (
+type BettererTest<T = unknown> = () => T | Promise<T>;
+type BettererConstraint<T = unknown> = (
   current: T,
   previous: T
 ) => boolean | Promise<boolean>;
 
 export type Betterer<T = number> = {
-  test: BetterTest<T>;
-  constraint: BetterConstraint<T>;
+  test: BettererTest<T>;
+  constraint: BettererConstraint<T>;
   goal: T;
 };
 
-export type BetterTests = {
+export type BettererTests = {
   [key: string]: Betterer;
 };
 
@@ -20,14 +20,14 @@ export type BettererConfig = {
   filters?: Array<RegExp>;
 };
 
-type BetterResult = {
+type BettererResult = {
   timestamp: number;
   value: string;
 };
 
-export type BetterResults = Record<string, BetterResult>;
+export type BettererResults = Record<string, BettererResult>;
 
-export type BetterStats = {
+export type BettererStats = {
   obsolete: Array<string>;
   ran: Array<string>;
   failed: Array<string>;


### PR DESCRIPTION
This stuff used to just be called `better`, so some internal things are named with the old name still. This fixes that!