### PR TITLE
(refactoring :hammer:) - constraints now control what "same" means

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,10 @@ It's also pretty straightforward to write your own custom **`betterer`**. All yo
 ```typescript
 export type Betterer<T = number> = {
   test: () => T | Promise<T>;
-  constraint: (current: T, previous: T) => boolean | Promise<boolean>;
+  constraint: (
+    current: T,
+    previous: T
+  ) => ConstraintResult | Promise<ConstraintResult>;
   goal: T;
 };
 ```

--- a/packages/betterer/package.json
+++ b/packages/betterer/package.json
@@ -24,6 +24,7 @@
     "compile": "tsc"
   },
   "dependencies": {
+    "@betterer/constraint": "^0.2.0",
     "@betterer/logger": "^0.2.0",
     "tslib": "^1.10.0"
   }

--- a/packages/betterer/src/betterer.ts
+++ b/packages/betterer/src/betterer.ts
@@ -1,3 +1,4 @@
+import { ConstraintResult } from '@betterer/constraints';
 import { error, info, success, warn } from '@betterer/logger';
 import { setConfig } from './config';
 import { print } from './printer';
@@ -88,7 +89,13 @@ export async function betterer(config: BettererConfig): Promise<BettererStats> {
       return;
     }
 
-    const isSame = current.value === previous.value;
+    const comparison = await constraint(
+      JSON.parse(current.value),
+      JSON.parse(previous.value)
+    );
+
+    const isSame = comparison === ConstraintResult.same;
+    const isBetter = comparison === ConstraintResult.better;
     const serialisedGoal = serialise(goal);
 
     // Same, but already met goal:
@@ -103,11 +110,6 @@ export async function betterer(config: BettererConfig): Promise<BettererStats> {
       stats.same.push(testName);
       return;
     }
-
-    const isBetter = await constraint(
-      JSON.parse(current.value),
-      JSON.parse(previous.value)
-    );
 
     // Better:
     if (isBetter) {

--- a/packages/betterer/src/types.ts
+++ b/packages/betterer/src/types.ts
@@ -1,8 +1,10 @@
+import { ConstraintResult } from '@betterer/constraints';
+
 type BettererTest<T = unknown> = () => T | Promise<T>;
 type BettererConstraint<T = unknown> = (
   current: T,
   previous: T
-) => boolean | Promise<boolean>;
+) => ConstraintResult | Promise<ConstraintResult>;
 
 export type Betterer<T = number> = {
   test: BettererTest<T>;

--- a/packages/constraints/README.md
+++ b/packages/constraints/README.md
@@ -9,11 +9,13 @@ Simple constraint functions for use with [**`betterer`**](https://github.com/phe
 ```typescript
 import { bigger, smaller } from '@betterer/constraints';
 
-bigger(1, 2); // false;
-bigger(1, 1); // false;
-bigger(2, 1); // true;
+bigger(1, 2); // worse;
+bigger(1, 1); // worse;
+bigger(2, 1); // better;
+bigger(2, 2); // same;
 
-smaller(2, 1); // false;
-smaller(1, 1); // false;
-smaller(1, 2); // true;
+smaller(2, 1); // worse;
+smaller(1, 1); // worse;
+smaller(1, 2); // better;
+smaller(2, 2); // same;
 ```

--- a/packages/constraints/src/bigger.ts
+++ b/packages/constraints/src/bigger.ts
@@ -1,3 +1,11 @@
-export function bigger(current: number, previous: number): boolean {
-  return current > previous;
+import { ConstraintResult } from './constraint-result';
+
+export function bigger(current: number, previous: number): ConstraintResult {
+  if (current === previous) {
+    return ConstraintResult.same;
+  }
+  if (current > previous) {
+    return ConstraintResult.better;
+  }
+  return ConstraintResult.worse;
 }

--- a/packages/constraints/src/constraint-result.ts
+++ b/packages/constraints/src/constraint-result.ts
@@ -1,0 +1,5 @@
+export const enum ConstraintResult {
+  better = 'better',
+  same = 'same',
+  worse = 'worse'
+}

--- a/packages/constraints/src/index.ts
+++ b/packages/constraints/src/index.ts
@@ -1,2 +1,4 @@
+export * from './constraint-result';
+
 export * from './bigger';
 export * from './smaller';

--- a/packages/constraints/src/smaller.ts
+++ b/packages/constraints/src/smaller.ts
@@ -1,3 +1,11 @@
-export function smaller(current: number, previous: number): boolean {
-  return current < previous;
+import { ConstraintResult } from './constraint-result';
+
+export function smaller(current: number, previous: number): ConstraintResult {
+  if (current === previous) {
+    return ConstraintResult.same;
+  }
+  if (current < previous) {
+    return ConstraintResult.better;
+  }
+  return ConstraintResult.worse;
 }


### PR DESCRIPTION
Turns out there are cases where you want to have more contorl of what it looks like for values to be the same. This adds an enum which allows you to do that, and updates the existing constraints.