### PR TITLE
(refactoring :hammer:) - making it easier to reason about serialisation

### DIFF
--- a/packages/betterer/src/serialiser.ts
+++ b/packages/betterer/src/serialiser.ts
@@ -1,12 +1,10 @@
-export function serialise(value: unknown): string {
-  return isJSON(value) ? value : JSON.stringify(value);
-}
+type Serialisable = {
+  serialise: () => unknown;
+};
 
-function isJSON(value: unknown): value is string {
-  try {
-    JSON.parse(value as string);
-    return typeof value === 'string';
-  } catch {
-    return false;
+export function serialise(value: unknown | Serialisable): unknown {
+  if (value && (value as Serialisable).serialise) {
+    return (value as Serialisable).serialise();
   }
+  return value;
 }

--- a/packages/betterer/src/stringifier.ts
+++ b/packages/betterer/src/stringifier.ts
@@ -1,0 +1,12 @@
+export function stringify(value: unknown): string {
+  return isJSON(value) ? value : JSON.stringify(value);
+}
+
+function isJSON(value: unknown): value is string {
+  try {
+    JSON.parse(value as string);
+    return typeof value === 'string';
+  } catch {
+    return false;
+  }
+}

--- a/packages/betterer/src/types.ts
+++ b/packages/betterer/src/types.ts
@@ -1,15 +1,15 @@
 import { ConstraintResult } from '@betterer/constraints';
 
-type BettererTest<T = unknown> = () => T | Promise<T>;
-type BettererConstraint<T = unknown> = (
+type BettererTest<T> = () => T | Promise<T>;
+type BettererConstraint<T> = (
   current: T,
   previous: T
 ) => ConstraintResult | Promise<ConstraintResult>;
 
-export type Betterer<T = number> = {
-  test: BettererTest<T>;
-  constraint: BettererConstraint<T>;
-  goal: T;
+export type Betterer<TestType = unknown, SerialisedType = TestType> = {
+  test: BettererTest<TestType>;
+  constraint: BettererConstraint<SerialisedType>;
+  goal: TestType;
 };
 
 export type BettererTests = {
@@ -18,11 +18,11 @@ export type BettererTests = {
 
 export type BettererConfig = {
   configPaths: Array<string>;
-  resultsPath?: string;
+  resultsPath: string;
   filters?: Array<RegExp>;
 };
 
-type BettererResult = {
+export type BettererResult = {
   timestamp: number;
   value: string;
 };

--- a/packages/eslint/src/eslint.ts
+++ b/packages/eslint/src/eslint.ts
@@ -11,7 +11,7 @@ type ESLintRuleConfig = [string, Linter.RuleLevel | Linter.RuleLevelAndOptions];
 export function eslintBetterer(
   files: string | Array<string>,
   rule: ESLintRuleConfig
-): Betterer {
+): Betterer<number> {
   const [, callee] = stack();
   const cwd = path.dirname(callee.getFileName());
   const filesArray = Array.isArray(files) ? files : [files];

--- a/packages/regexp/src/regexp.ts
+++ b/packages/regexp/src/regexp.ts
@@ -14,7 +14,7 @@ const readAsync = promisify(fs.readFile);
 export function regexpBetterer(
   files: string | Array<string>,
   regexp: RegExp
-): Betterer {
+): Betterer<number> {
   const [, callee] = stack();
   const cwd = path.dirname(callee.getFileName());
   const filesArray = Array.isArray(files) ? files : [files];

--- a/packages/tsquery/src/tsquery.ts
+++ b/packages/tsquery/src/tsquery.ts
@@ -9,7 +9,7 @@ import { code, error, info, LoggerCodeInfo } from '@betterer/logger';
 export function tsqueryBetterer(
   configFilePath: string,
   query: string
-): Betterer {
+): Betterer<number> {
   const [, callee] = stack();
   const cwd = path.dirname(callee.getFileName());
   const absPath = path.resolve(cwd, configFilePath);

--- a/packages/typescript/src/typescript.ts
+++ b/packages/typescript/src/typescript.ts
@@ -12,7 +12,7 @@ const readDirectory = ts.sys.readDirectory.bind(ts.sys);
 export function typescriptBetterer(
   configFilePath: string,
   extraCompilerOptions?: ts.CompilerOptions
-): Betterer {
+): Betterer<number> {
   const [, callee] = stack();
   const cwd = path.dirname(callee.getFileName());
   const absPath = path.resolve(cwd, configFilePath);


### PR DESCRIPTION
The current serialisation logic is a bit hard to follow, and pretty inflexible for types beyond numbers. This improves that. It also makes it do that the .results file won't be updated if the values haven't changed so you have a stable date of when the value was last improved.