### PR TITLE
Correct ts strict config documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ const { typescriptBetterer } = require('@betterer/typescript');
 
 module.exports = {
   'stricter compilation': typescriptBetterer('./tsconfig.json', {
-    useStrict: true
+    strict: true
   })
 };
 ```


### PR DESCRIPTION
`useStrict` isn't a valid ts config option and it's tripped me up a few times, ha.