### PR TITLE
Ensure snapshots don't break due to invalid syntax

### DIFF
--- a/packages/betterer/src/printer.ts
+++ b/packages/betterer/src/printer.ts
@@ -16,6 +16,7 @@ export function print(results: BettererResults): string {
           ? (value as Printable).print()
           : JSON.stringify(value);
     }
+    printedValue = (printedValue as string).replace(/`/g, '\\`');
     return `\nexports[\`${resultName}\`] = {\n  timestamp: ${timestamp},\n  value: \`${printedValue}\`\n};`;
   });
 


### PR DESCRIPTION
Fixes #24 

Typescript (and potentially other things) can output a  ` symbol in their results which would break the snapshot formatting. 