### PR TITLE
Ensure serialized ts errors can be read back in

### DIFF
--- a/packages/betterer/package.json
+++ b/packages/betterer/package.json
@@ -28,6 +28,7 @@
     "@betterer/logger": "^0.3.0",
     "jest-diff": "^24.9.0",
     "lines-and-columns": "^1.1.6",
+    "safe-string-literal": "^1.0.1",
     "tslib": "^1.10.0"
   }
 }

--- a/packages/betterer/src/files/file-info.ts
+++ b/packages/betterer/src/files/file-info.ts
@@ -66,7 +66,9 @@ export class BettererFileInfo {
           printed += ',\n';
         }
         const [line, column, length, message] = mark;
-        printed += `      [${line}, ${column}, ${length}, "${message}"]`;
+        printed += `      [${line}, ${column}, ${length}, ${JSON.stringify(
+          message
+        )}]`;
       });
       printed += `\n    ]`;
     });

--- a/packages/betterer/src/printer.ts
+++ b/packages/betterer/src/printer.ts
@@ -1,4 +1,5 @@
 import { BettererResults } from './types';
+import { escape } from 'safe-string-literal';
 
 const RESULTS_HEADER = `// BETTERER RESULTS V1.`;
 
@@ -16,8 +17,10 @@ export function print(results: BettererResults): string {
           ? (value as Printable).print()
           : JSON.stringify(value);
     }
-    printedValue = (printedValue as string).replace(/`/g, '\\`');
-    return `\nexports[\`${resultName}\`] = {\n  timestamp: ${timestamp},\n  value: \`${printedValue}\`\n};`;
+    return `\nexports[\`${resultName}\`] = {\n  timestamp: ${timestamp},\n  value: \`${escape(
+      printedValue as string,
+      '"\n'
+    )}\`\n};`;
   });
 
   return [RESULTS_HEADER, ...printed].join('');

--- a/packages/betterer/src/printer.ts
+++ b/packages/betterer/src/printer.ts
@@ -7,6 +7,9 @@ type Printable = {
   print: () => string;
 };
 
+/** Characters that we avoid escaping to make snapshots easier to visually diff */
+const UNESCAPED = '"\n';
+
 export function print(results: BettererResults): string {
   const printed = Object.keys(results).map(resultName => {
     const { timestamp, value } = results[resultName];
@@ -19,7 +22,7 @@ export function print(results: BettererResults): string {
     }
     return `\nexports[\`${resultName}\`] = {\n  timestamp: ${timestamp},\n  value: \`${escape(
       printedValue as string,
-      '"\n'
+      UNESCAPED
     )}\`\n};`;
   });
 

--- a/test/__snapshots__/betterer-eslint.spec.ts.snap
+++ b/test/__snapshots__/betterer-eslint.spec.ts.snap
@@ -6,7 +6,7 @@ exports[\`eslint enable new rule\`] = {
   timestamp: 0,
   value: \`{
     \\"../src/index.ts\\": [
-      [0, 0, 9, \\"Unexpected 'debugger' statement.\\"]
+      [0, 0, 9, \\"Unexpected \\\\'debugger\\\\' statement.\\"]
     ]
   }\`
 };"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5766,6 +5766,11 @@ safe-regex@^1.1.0:
   dependencies:
     ret "~0.1.10"
 
+safe-string-literal@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/safe-string-literal/-/safe-string-literal-1.0.1.tgz#ca6d332bad223ce3233c38142e05c1c3cc7f76bb"
+  integrity sha512-qxlBSDdbeaJbk7tPeNg04+maY8B6HFBRuePIOfDqTZzbD4NXZTbrpRVcJGsmG88OpB30SYKJDqFjvUqnujdpew==
+
 "safer-buffer@>= 2.1.2 < 3", safer-buffer@^2.0.2, safer-buffer@^2.1.0, safer-buffer@~2.1.0:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"


### PR DESCRIPTION
This really needs some good tests, but after a few days of poking I _finally_ got our ts checks working again. 

I don't have a minimal reproduction right now, but you can reproduce the failure on https://github.com/artsy/reaction/pull/2864 easily enough. 

To repo:

1. delete the `.betterer.results` file
2. run `yarn betterer` (which will generate the results file)
3. run `yarn betterer` again. 

On the last step betterer will fail with somewhat vague error about not being able to read the results (see below). Ultimately the error is caused by a `JSON.parse` that blows up. 

```
☀️  betterer  erro  🔥  -  could not read results from "~/Git/artsy/reaction/.betterer.results". 😔
(node:38146) UnhandledPromiseRejectionWarning: Error
    at Object.<anonymous> (~/Git/artsy/reaction/node_modules/@betterer/betterer/dist/betterer.js:91:17)
```

There are a few parts to this, so I'm going to do a little PR tour inspired by some of my colleagues. 

:triangular_flag_on_post: [Follow along here](https://github.com/phenomnomnominal/betterer/pull/26/files#r348297480)
