### PR TITLE
Add ts incremental compilation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules
 reports
 lerna-debug.log
 yarn-error.log
+tsconfig.tsbuildinfo

--- a/fixtures/test-betterer-typescript/tsconfig.json
+++ b/fixtures/test-betterer-typescript/tsconfig.json
@@ -1,4 +1,11 @@
 {
-  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "lib": ["esnext"],
+    "moduleResolution": "node",
+    "target": "ES5",
+    "typeRoots": ["../../node_modules/@types/"],
+    "resolveJsonModule": true
+  },
   "include": ["./src/**/*", ".betterer.ts"]
 }

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "betterer": "node ./packages/cli/./bin/betterer",
     "build": "yarn clean && yarn && yarn lint && yarn compile && yarn test && yarn betterer",
     "clean": "rimraf reports && lerna exec \"rimraf dist\" && lerna exec \"rimraf node_modules\" && rimraf node_modules",
-    "compile": "lerna run compile",
+    "compile": "tsc -p packages",
     "lint": "eslint --fix ./packages/**/src/*.ts ./test/**/*.ts ./*.js",
     "test": "jest",
     "test:debug": "jest --runInBand",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   ],
   "scripts": {
     "betterer": "node ./packages/cli/./bin/betterer",
-    "build": "yarn clean && lerna bootstrap && yarn lint && yarn compile && yarn test && yarn betterer",
+    "build": "yarn clean && yarn && yarn lint && yarn compile && yarn test && yarn betterer",
     "clean": "rimraf reports && lerna exec \"rimraf dist\" && rimraf ./**/tsconfig.tsbuildinfo && lerna exec \"rimraf node_modules\" && rimraf node_modules",
     "compile": "tsc -b packages",
     "lint": "eslint --fix ./packages/**/src/*.ts ./test/**/*.ts ./*.js",

--- a/package.json
+++ b/package.json
@@ -10,9 +10,9 @@
   ],
   "scripts": {
     "betterer": "node ./packages/cli/./bin/betterer",
-    "build": "yarn clean && yarn && yarn lint && yarn compile && yarn test && yarn betterer",
-    "clean": "rimraf reports && lerna exec \"rimraf dist\" && lerna exec \"rimraf node_modules\" && rimraf node_modules",
-    "compile": "tsc -p packages",
+    "build": "yarn clean && lerna bootstrap && yarn lint && yarn compile && yarn test && yarn betterer",
+    "clean": "rimraf reports && lerna exec \"rimraf dist\" && rimraf ./**/tsconfig.tsbuildinfo && lerna exec \"rimraf node_modules\" && rimraf node_modules",
+    "compile": "tsc -b packages",
     "lint": "eslint --fix ./packages/**/src/*.ts ./test/**/*.ts ./*.js",
     "test": "jest",
     "test:debug": "jest --runInBand",

--- a/packages/betterer/package.json
+++ b/packages/betterer/package.json
@@ -21,7 +21,7 @@
     "url": "https://github.com/phenomnomnominal/betterer/issues"
   },
   "scripts": {
-    "compile": "tsc"
+    "compile": "tsc -b  ."
   },
   "dependencies": {
     "@betterer/constraints": "^0.3.0",

--- a/packages/betterer/package.json
+++ b/packages/betterer/package.json
@@ -21,7 +21,7 @@
     "url": "https://github.com/phenomnomnominal/betterer/issues"
   },
   "scripts": {
-    "compile": "tsc -b  ."
+    "compile": "tsc -b ."
   },
   "dependencies": {
     "@betterer/constraints": "^0.3.0",

--- a/packages/betterer/tsconfig.json
+++ b/packages/betterer/tsconfig.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "outDir": "./dist"
   },
-  "include": ["./src/*.ts"],
-  "exclude": ["../node_modules/*", "./node_modules/*", "./dist/*"]
+  "include": ["./src/**/*.ts"],
+  "exclude": ["../node_modules/*", "./node_modules/*", "./dist/*"],
+  "references": [{ "path": "../constraints" }, { "path": "../logger" }]
 }

--- a/packages/betterer/tsconfig.json
+++ b/packages/betterer/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "outDir": "./dist"
+    "outDir": "./dist",
+    "rootDir": "./src"
   },
   "include": ["./src/**/*.ts"],
   "exclude": ["../node_modules/*", "./node_modules/*", "./dist/*"],

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -25,7 +25,7 @@
     "url": "https://github.com/phenomnomnominal/betterer/issues"
   },
   "scripts": {
-    "compile": "tsc -b  ."
+    "compile": "tsc -b ."
   },
   "dependencies": {
     "@betterer/betterer": "^0.3.4",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -25,7 +25,7 @@
     "url": "https://github.com/phenomnomnominal/betterer/issues"
   },
   "scripts": {
-    "compile": "tsc"
+    "compile": "tsc -b  ."
   },
   "dependencies": {
     "@betterer/betterer": "^0.3.4",

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "outDir": "./dist"
+    "outDir": "./dist",
+    "rootDir": "./src"
   },
   "include": ["./src/*.ts"],
   "exclude": ["../node_modules/*", "./node_modules/*", "./dist/*"],

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -4,5 +4,6 @@
     "outDir": "./dist"
   },
   "include": ["./src/*.ts"],
-  "exclude": ["../node_modules/*", "./node_modules/*", "./dist/*"]
+  "exclude": ["../node_modules/*", "./node_modules/*", "./dist/*"],
+  "references": [{ "path": "../betterer" }, { "path": "../logger" }]
 }

--- a/packages/constraints/package.json
+++ b/packages/constraints/package.json
@@ -21,7 +21,7 @@
     "url": "https://github.com/phenomnomnominal/betterer/issues"
   },
   "scripts": {
-    "compile": "tsc -b  ."
+    "compile": "tsc -b ."
   },
   "dependencies": {
     "tslib": "^1.10.0"

--- a/packages/constraints/package.json
+++ b/packages/constraints/package.json
@@ -21,7 +21,7 @@
     "url": "https://github.com/phenomnomnominal/betterer/issues"
   },
   "scripts": {
-    "compile": "tsc"
+    "compile": "tsc -b  ."
   },
   "dependencies": {
     "tslib": "^1.10.0"

--- a/packages/constraints/tsconfig.json
+++ b/packages/constraints/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "outDir": "./dist"
+    "outDir": "./dist",
+    "rootDir": "./src"
   },
   "include": ["./src/*.ts"],
   "exclude": ["../node_modules/*", "./node_modules/*", "./dist/*"]

--- a/packages/eslint/package.json
+++ b/packages/eslint/package.json
@@ -21,7 +21,7 @@
     "url": "https://github.com/phenomnomnominal/betterer/issues"
   },
   "scripts": {
-    "compile": "tsc"
+    "compile": "tsc -b  ."
   },
   "dependencies": {
     "@betterer/betterer": "^0.3.4",

--- a/packages/eslint/package.json
+++ b/packages/eslint/package.json
@@ -21,7 +21,7 @@
     "url": "https://github.com/phenomnomnominal/betterer/issues"
   },
   "scripts": {
-    "compile": "tsc -b  ."
+    "compile": "tsc -b ."
   },
   "dependencies": {
     "@betterer/betterer": "^0.3.4",

--- a/packages/eslint/tsconfig.json
+++ b/packages/eslint/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "outDir": "./dist"
+    "outDir": "./dist",
+    "rootDir": "./src"
   },
   "include": ["./src/*.ts"],
   "exclude": ["../node_modules/*", "./node_modules/*", "./dist/*"],

--- a/packages/eslint/tsconfig.json
+++ b/packages/eslint/tsconfig.json
@@ -4,5 +4,6 @@
     "outDir": "./dist"
   },
   "include": ["./src/*.ts"],
-  "exclude": ["../node_modules/*", "./node_modules/*", "./dist/*"]
+  "exclude": ["../node_modules/*", "./node_modules/*", "./dist/*"],
+  "references": [{ "path": "../betterer" }, { "path": "../logger" }]
 }

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -21,7 +21,7 @@
     "url": "https://github.com/phenomnomnominal/betterer/issues"
   },
   "scripts": {
-    "compile": "tsc"
+    "compile": "tsc -b  ."
   },
   "dependencies": {
     "@babel/code-frame": "^7.5.5",

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -21,7 +21,7 @@
     "url": "https://github.com/phenomnomnominal/betterer/issues"
   },
   "scripts": {
-    "compile": "tsc -b  ."
+    "compile": "tsc -b ."
   },
   "dependencies": {
     "@babel/code-frame": "^7.5.5",

--- a/packages/logger/tsconfig.json
+++ b/packages/logger/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "outDir": "./dist"
+    "outDir": "./dist",
+    "rootDir": "./src"
   },
   "include": ["./src/*.ts"],
   "exclude": ["../node_modules/*", "./node_modules/*", "./dist/*"]

--- a/packages/regexp/package.json
+++ b/packages/regexp/package.json
@@ -21,7 +21,7 @@
     "url": "https://github.com/phenomnomnominal/betterer/issues"
   },
   "scripts": {
-    "compile": "tsc"
+    "compile": "tsc -b  ."
   },
   "dependencies": {
     "@betterer/betterer": "^0.3.4",

--- a/packages/regexp/package.json
+++ b/packages/regexp/package.json
@@ -21,7 +21,7 @@
     "url": "https://github.com/phenomnomnominal/betterer/issues"
   },
   "scripts": {
-    "compile": "tsc -b  ."
+    "compile": "tsc -b ."
   },
   "dependencies": {
     "@betterer/betterer": "^0.3.4",

--- a/packages/regexp/tsconfig.json
+++ b/packages/regexp/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "outDir": "./dist"
+    "outDir": "./dist",
+    "rootDir": "./src"
   },
   "include": ["./src/*.ts"],
   "exclude": ["../node_modules/*", "./node_modules/*", "./dist/*"],

--- a/packages/regexp/tsconfig.json
+++ b/packages/regexp/tsconfig.json
@@ -4,5 +4,6 @@
     "outDir": "./dist"
   },
   "include": ["./src/*.ts"],
-  "exclude": ["../node_modules/*", "./node_modules/*", "./dist/*"]
+  "exclude": ["../node_modules/*", "./node_modules/*", "./dist/*"],
+  "references": [{ "path": "../betterer" }, { "path": "../logger" }]
 }

--- a/packages/tsconfig.json
+++ b/packages/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "files": [],
+  "references": [
+    { "path": "betterer" },
+    { "path": "cli" },
+    { "path": "constraints" },
+    { "path": "eslint" },
+    { "path": "logger" },
+    { "path": "regexp" },
+    { "path": "tsquery" },
+    { "path": "typescript" }
+  ]
+}

--- a/packages/tsquery/package.json
+++ b/packages/tsquery/package.json
@@ -21,7 +21,7 @@
     "url": "https://github.com/phenomnomnominal/betterer/issues"
   },
   "scripts": {
-    "compile": "tsc"
+    "compile": "tsc -b  ."
   },
   "dependencies": {
     "@betterer/betterer": "^0.3.4",

--- a/packages/tsquery/package.json
+++ b/packages/tsquery/package.json
@@ -21,7 +21,7 @@
     "url": "https://github.com/phenomnomnominal/betterer/issues"
   },
   "scripts": {
-    "compile": "tsc -b  ."
+    "compile": "tsc -b ."
   },
   "dependencies": {
     "@betterer/betterer": "^0.3.4",

--- a/packages/tsquery/tsconfig.json
+++ b/packages/tsquery/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "outDir": "./dist"
+    "outDir": "./dist",
+    "rootDir": "./src"
   },
   "include": ["./src/*.ts"],
   "exclude": ["../node_modules/*", "./node_modules/*", "./dist/*"],

--- a/packages/tsquery/tsconfig.json
+++ b/packages/tsquery/tsconfig.json
@@ -4,5 +4,6 @@
     "outDir": "./dist"
   },
   "include": ["./src/*.ts"],
-  "exclude": ["../node_modules/*", "./node_modules/*", "./dist/*"]
+  "exclude": ["../node_modules/*", "./node_modules/*", "./dist/*"],
+  "references": [{ "path": "../betterer" }, { "path": "../logger" }]
 }

--- a/packages/typescript/package.json
+++ b/packages/typescript/package.json
@@ -21,7 +21,7 @@
     "url": "https://github.com/phenomnomnominal/betterer/issues"
   },
   "scripts": {
-    "compile": "tsc"
+    "compile": "tsc -b  ."
   },
   "dependencies": {
     "@betterer/betterer": "^0.3.4",

--- a/packages/typescript/package.json
+++ b/packages/typescript/package.json
@@ -21,7 +21,7 @@
     "url": "https://github.com/phenomnomnominal/betterer/issues"
   },
   "scripts": {
-    "compile": "tsc -b  ."
+    "compile": "tsc -b ."
   },
   "dependencies": {
     "@betterer/betterer": "^0.3.4",

--- a/packages/typescript/tsconfig.json
+++ b/packages/typescript/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "outDir": "./dist"
+    "outDir": "./dist",
+    "rootDir": "./src"
   },
   "include": ["./src/*.ts"],
   "exclude": ["../node_modules/*", "./node_modules/*", "./dist/*"],

--- a/packages/typescript/tsconfig.json
+++ b/packages/typescript/tsconfig.json
@@ -4,5 +4,6 @@
     "outDir": "./dist"
   },
   "include": ["./src/*.ts"],
-  "exclude": ["../node_modules/*", "./node_modules/*", "./dist/*"]
+  "exclude": ["../node_modules/*", "./node_modules/*", "./dist/*"],
+  "references": [{ "path": "../betterer" }, { "path": "../logger" }]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,8 +16,8 @@
     "target": "ES5",
     "outDir": "./dist",
     "typeRoots": ["./node_modules/@types/"],
-    "resolveJsonModule": true
-  },
-  "include": ["./packages/**/src/*.ts", "./test/**/*.ts", "./*.js"],
-  "exclude": ["./node_modules/*", "./dist/*"]
+    "resolveJsonModule": true,
+    "composite": true,
+    "incremental": true
+  }
 }


### PR DESCRIPTION
Fixes #18 

This adds support for typescript incremental compilation and project references. Essentially, when the project builds it actually builds each individual project, but only when it's needed. It'll keep a cache version around and each project knows about its dependencies and _won't_ recompile them if they haven't changed. This'll  make development _much_ faster.  