### PR TITLE
feat(eslint ✨): handle changing multiple rules at the same time

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -18,36 +18,63 @@ exports[`no raw console.log`] = {
     ]
   }`
 };
-exports[`@typescript-eslint/ban-types`] = {
-  timestamp: 1592972177676,
+exports[`new eslint rules`] = {
+  timestamp: 1593096621756,
   value: `{
-    "packages/betterer/src/context/context.ts:3853906370": [
-      [29, 19, 8, "Don\'t use \`Function\` as a type. The \`Function\` type accepts any function-like value.\\nIt provides no type safety when calling the function, which can be a common source of bugs.\\nIt also accepts things like class declarations, which will throw at runtime as they will not be called with \`new\`.\\nIf you are expecting the function to accept certain arguments, you should explicitly define the function shape.", "4136871687"]
+    "packages/betterer/src/config/config.ts:3840038520": [
+      [30, 2, 72, "Unsafe return of an any[] typed value", "2233173152"]
     ],
-    "packages/betterer/src/utils.ts:38796100": [
-      [2, 53, 8, "Don\'t use \`Function\` as a type. The \`Function\` type accepts any function-like value.\\nIt provides no type safety when calling the function, which can be a common source of bugs.\\nIt also accepts things like class declarations, which will throw at runtime as they will not be called with \`new\`.\\nIf you are expecting the function to accept certain arguments, you should explicitly define the function shape.", "4136871687"]
-    ]
-  }`
-};
-exports[`@typescript-eslint/restrict-template-expressions`] = {
-  timestamp: 1592972180845,
-  value: `{
+    "packages/betterer/src/context/context.ts:3853906370": [
+      [29, 19, 8, "Don\'t use \`Function\` as a type. The \`Function\` type accepts any function-like value.\\nIt provides no type safety when calling the function, which can be a common source of bugs.\\nIt also accepts things like class declarations, which will throw at runtime as they will not be called with \`new\`.\\nIf you are expecting the function to accept certain arguments, you should explicitly define the function shape.", "4136871687"],
+      [146, 6, 9, "Unsafe assignment of an any value.", "166477157"]
+    ],
     "packages/betterer/src/errors.ts:3973991685": [
       [7, 96, 10, "Invalid type \\"string | Error | BettererError\\" of template literal expression.", "3805115554"],
       [8, 99, 11, "Invalid type \\"string | Error | BettererError\\" of template literal expression.", "2365839858"],
       [9, 99, 11, "Invalid type \\"string | Error | BettererError\\" of template literal expression.", "2365839858"]
     ],
+    "packages/betterer/src/register.ts:845928349": [
+      [17, 8, 39, "Unsafe assignment of an any value.", "2552944516"],
+      [20, 8, 29, "Unsafe assignment of an any value.", "4025951506"],
+      [20, 13, 24, "Unsafe member access [JS_EXTENSION] on an any value.", "1928379798"],
+      [22, 7, 24, "Unsafe member access [TS_EXTENSION] on an any value.", "1899174408"],
+      [37, 2, 29, "Unsafe member access [RESULTS_EXTENTION] on an any value.", "1793441202"],
+      [38, 4, 2, "Unsafe call of an any typed value.", "5862300"]
+    ],
+    "packages/betterer/src/require.ts:3480205399": [
+      [5, 8, 24, "Unsafe assignment of an any value.", "3354533529"],
+      [6, 2, 22, "Unsafe return of an any typed value", "880393137"],
+      [6, 9, 9, "Unsafe member access .default on an any value.", "3809326797"],
+      [18, 2, 38, "Unsafe return of an any typed value", "2611709393"],
+      [18, 9, 17, "Unsafe member access .default on an any value.", "3645928756"]
+    ],
+    "packages/betterer/src/results/deserialiser.ts:3618777338": [
+      [4, 8, 31, "Unsafe assignment of an any value.", "624767152"]
+    ],
+    "packages/betterer/src/utils.ts:38796100": [
+      [2, 53, 8, "Don\'t use \`Function\` as a type. The \`Function\` type accepts any function-like value.\\nIt provides no type safety when calling the function, which can be a common source of bugs.\\nIt also accepts things like class declarations, which will throw at runtime as they will not be called with \`new\`.\\nIf you are expecting the function to accept certain arguments, you should explicitly define the function shape.", "4136871687"]
+    ],
+    "packages/cli/src/cli.ts:2439790794": [
+      [16, 6, 40, "Unsafe assignment of an any value.", "959029483"]
+    ],
     "packages/cli/src/errors.ts:4053971182": [
       [2, 90, 10, "Invalid type \\"string | Error | BettererError\\" of template literal expression.", "3805115554"]
     ],
     "packages/cli/src/init.ts:4030003562": [
+      [74, 4, 69, "Unsafe assignment of an any value.", "3315440333"],
+      [79, 2, 47, "Unsafe assignment of an any value.", "4106472126"],
+      [79, 2, 19, "Unsafe member access .scripts on an any value.", "3595083989"],
+      [79, 24, 19, "Unsafe member access .scripts on an any value.", "3595083989"],
+      [80, 6, 19, "Unsafe member access .scripts on an any value.", "3595083989"],
+      [84, 4, 19, "Unsafe member access .scripts on an any value.", "3595083989"],
+      [87, 2, 63, "Unsafe assignment of an any value.", "4237347454"],
+      [87, 2, 27, "Unsafe member access .devDependencies on an any value.", "2927433783"],
+      [87, 32, 27, "Unsafe member access .devDependencies on an any value.", "2927433783"],
+      [88, 6, 27, "Unsafe member access .devDependencies on an any value.", "2927433783"],
+      [95, 10, 40, "Unsafe assignment of an any value.", "959029483"],
+      [96, 4, 27, "Unsafe member access .devDependencies on an any value.", "2927433783"],
       [96, 55, 7, "Invalid type \\"any\\" of template literal expression.", "800248767"]
-    ]
-  }`
-};
-exports[`@typescript-eslint/no-floating-promises`] = {
-  timestamp: 1592976958176,
-  value: `{
+    ],
     "packages/cli/src/watch.ts:2535787765": [
       [24, 6, 15, "Promises must be handled appropriately or explicitly marked as ignored with the \`void\` operator.", "733721943"]
     ],
@@ -76,6 +103,21 @@ exports[`@typescript-eslint/no-floating-promises`] = {
       [28, 4, 25, "Promises must be handled appropriately or explicitly marked as ignored with the \`void\` operator.", "3494514196"],
       [74, 6, 32, "Promises must be handled appropriately or explicitly marked as ignored with the \`void\` operator.", "694099710"]
     ],
+    "packages/extension/src/server/betterer.ts:4211891793": [
+      [16, 8, 24, "Unsafe assignment of an any value.", "1072779174"],
+      [17, 8, 34, "Unsafe assignment of an any value.", "1696192854"],
+      [17, 26, 16, "Unsafe member access .betterer on an any value.", "2086049363"]
+    ],
+    "packages/extension/src/server/config.ts:3376275560": [
+      [12, 4, 23, "Unsafe assignment of an any value.", "4217090156"],
+      [13, 4, 7, "Unsafe assignment of an any value.", "1789297334"],
+      [14, 4, 11, "Unsafe assignment of an any value.", "2365839858"],
+      [15, 4, 55, "Unsafe assignment of an any value.", "1958731456"],
+      [21, 2, 59, "Unsafe return of type Promise<any> from function with return type Promise<WorkspaceConfiguration>.", "3903064458"]
+    ],
+    "packages/extension/src/server/notifications/validate.ts:2562732250": [
+      [18, 4, 38, "Unsafe asignment of type Map<any, any> to a variable of type Map<string, { handler: NotificationHandler<TextDocument>; versionProvider: BettererVersionProvider; }>.", "2572650248"]
+    ],
     "packages/extension/src/server/server.ts:2004201515": [
       [62, 4, 68, "Promises must be handled appropriately or explicitly marked as ignored with the \`void\` operator.", "280309533"],
       [63, 4, 71, "Promises must be handled appropriately or explicitly marked as ignored with the \`void\` operator.", "2936064845"],
@@ -83,132 +125,30 @@ exports[`@typescript-eslint/no-floating-promises`] = {
     ],
     "packages/extension/src/server/validator.ts:3637606391": [
       [47, 10, 90, "Promises must be handled appropriately or explicitly marked as ignored with the \`void\` operator.", "1821734533"],
-      [93, 12, 94, "Promises must be handled appropriately or explicitly marked as ignored with the \`void\` operator.", "2449957056"]
-    ]
-  }`
-};
-exports[`@typescript-eslint/no-unsafe-assignment`] = {
-  timestamp: 1592972182811,
-  value: `{
-    "packages/betterer/src/context/context.ts:3853906370": [
-      [146, 6, 9, "Unsafe assignment of an any value.", "166477157"]
-    ],
-    "packages/betterer/src/register.ts:845928349": [
-      [17, 8, 39, "Unsafe assignment of an any value.", "2552944516"],
-      [20, 8, 29, "Unsafe assignment of an any value.", "4025951506"]
-    ],
-    "packages/betterer/src/require.ts:3480205399": [
-      [5, 8, 24, "Unsafe assignment of an any value.", "3354533529"]
-    ],
-    "packages/betterer/src/results/deserialiser.ts:3618777338": [
-      [4, 8, 31, "Unsafe assignment of an any value.", "624767152"]
-    ],
-    "packages/cli/src/cli.ts:2439790794": [
-      [16, 6, 40, "Unsafe assignment of an any value.", "959029483"]
-    ],
-    "packages/cli/src/init.ts:4030003562": [
-      [74, 4, 69, "Unsafe assignment of an any value.", "3315440333"],
-      [79, 2, 47, "Unsafe assignment of an any value.", "4106472126"],
-      [87, 2, 63, "Unsafe assignment of an any value.", "4237347454"],
-      [95, 10, 40, "Unsafe assignment of an any value.", "959029483"]
-    ],
-    "packages/extension/src/server/betterer.ts:4211891793": [
-      [16, 8, 24, "Unsafe assignment of an any value.", "1072779174"],
-      [17, 8, 34, "Unsafe assignment of an any value.", "1696192854"]
-    ],
-    "packages/extension/src/server/config.ts:3376275560": [
-      [12, 4, 23, "Unsafe assignment of an any value.", "4217090156"],
-      [13, 4, 7, "Unsafe assignment of an any value.", "1789297334"],
-      [14, 4, 11, "Unsafe assignment of an any value.", "2365839858"],
-      [15, 4, 55, "Unsafe assignment of an any value.", "1958731456"]
-    ],
-    "packages/extension/src/server/notifications/validate.ts:2562732250": [
-      [18, 4, 38, "Unsafe asignment of type Map<any, any> to a variable of type Map<string, { handler: NotificationHandler<TextDocument>; versionProvider: BettererVersionProvider; }>.", "2572650248"]
-    ],
-    "packages/extension/src/server/validator.ts:3637606391": [
+      [71, 44, 17, "Computed name [file.relativePath] resolves to an any value.", "50828020"],
       [79, 16, 26, "Unsafe assignment of an any value.", "3761557800"],
-      [81, 16, 31, "Unsafe assignment of an any value.", "3291696295"]
+      [81, 16, 31, "Unsafe assignment of an any value.", "3291696295"],
+      [93, 12, 94, "Promises must be handled appropriately or explicitly marked as ignored with the \`void\` operator.", "2449957056"]
     ],
-    "packages/typescript/src/typescript.ts:3207668848": [
+    "packages/typescript/src/typescript.ts:405611543": [
       [20, 12, 6, "Unsafe array destructuring of a tuple element with an any value.", "1544266319"],
       [21, 10, 28, "Unsafe assignment of an any value.", "1730011879"],
       [24, 10, 85, "Unsafe assignment of an any value.", "1072556674"],
-      [28, 4, 44, "Unsafe assignment of an any value.", "2615138127"]
+      [28, 4, 44, "Unsafe assignment of an any value.", "2615138127"],
+      [28, 4, 22, "Unsafe member access .compilerOptions on an any value.", "3579262450"]
     ],
     "test/cli/betterer-init.spec.ts:41535933": [
-      [23, 10, 57, "Unsafe assignment of an any value.", "1827640456"]
+      [23, 10, 57, "Unsafe assignment of an any value.", "1827640456"],
+      [25, 11, 19, "Unsafe member access .scripts on an any value.", "3595083989"],
+      [26, 11, 27, "Unsafe member access .devDependencies on an any value.", "2927433783"]
     ],
     "test/cli/betterer-version.spec.ts:2875213250": [
       [6, 10, 56, "Unsafe assignment of an any value.", "702246347"]
     ],
     "test/fixture.ts:4010096081": [
-      [83, 10, 33, "Unsafe assignment of an any value.", "2802723694"]
-    ]
-  }`
-};
-exports[`@typescript-eslint/no-unsafe-call`] = {
-  timestamp: 1592972183779,
-  value: `{
-    "packages/betterer/src/register.ts:845928349": [
-      [38, 4, 2, "Unsafe call of an any typed value.", "5862300"]
-    ],
-    "test/fixture.ts:4010096081": [
+      [83, 10, 33, "Unsafe assignment of an any value.", "2802723694"],
+      [83, 24, 13, "Unsafe member access .split on an any value.", "2353790866"],
       [83, 24, 13, "Unsafe call of an any typed value.", "2353790866"]
-    ]
-  }`
-};
-exports[`@typescript-eslint/no-unsafe-member-access`] = {
-  timestamp: 1592972184598,
-  value: `{
-    "packages/betterer/src/register.ts:845928349": [
-      [20, 13, 24, "Unsafe member access [JS_EXTENSION] on an any value.", "1928379798"],
-      [22, 7, 24, "Unsafe member access [TS_EXTENSION] on an any value.", "1899174408"],
-      [37, 2, 29, "Unsafe member access [RESULTS_EXTENTION] on an any value.", "1793441202"]
-    ],
-    "packages/betterer/src/require.ts:3480205399": [
-      [6, 9, 9, "Unsafe member access .default on an any value.", "3809326797"],
-      [18, 9, 17, "Unsafe member access .default on an any value.", "3645928756"]
-    ],
-    "packages/cli/src/init.ts:4030003562": [
-      [79, 2, 19, "Unsafe member access .scripts on an any value.", "3595083989"],
-      [79, 24, 19, "Unsafe member access .scripts on an any value.", "3595083989"],
-      [80, 6, 19, "Unsafe member access .scripts on an any value.", "3595083989"],
-      [84, 4, 19, "Unsafe member access .scripts on an any value.", "3595083989"],
-      [87, 2, 27, "Unsafe member access .devDependencies on an any value.", "2927433783"],
-      [87, 32, 27, "Unsafe member access .devDependencies on an any value.", "2927433783"],
-      [88, 6, 27, "Unsafe member access .devDependencies on an any value.", "2927433783"],
-      [96, 4, 27, "Unsafe member access .devDependencies on an any value.", "2927433783"]
-    ],
-    "packages/extension/src/server/betterer.ts:4211891793": [
-      [17, 26, 16, "Unsafe member access .betterer on an any value.", "2086049363"]
-    ],
-    "packages/extension/src/server/validator.ts:3637606391": [
-      [71, 44, 17, "Computed name [file.relativePath] resolves to an any value.", "50828020"]
-    ],
-    "packages/typescript/src/typescript.ts:3207668848": [
-      [28, 4, 22, "Unsafe member access .compilerOptions on an any value.", "3579262450"]
-    ],
-    "test/cli/betterer-init.spec.ts:41535933": [
-      [25, 11, 19, "Unsafe member access .scripts on an any value.", "3595083989"],
-      [26, 11, 27, "Unsafe member access .devDependencies on an any value.", "2927433783"]
-    ],
-    "test/fixture.ts:4010096081": [
-      [83, 24, 13, "Unsafe member access .split on an any value.", "2353790866"]
-    ]
-  }`
-};
-exports[`@typescript-eslint/no-unsafe-return`] = {
-  timestamp: 1592972185416,
-  value: `{
-    "packages/betterer/src/config/config.ts:3840038520": [
-      [30, 2, 72, "Unsafe return of an any[] typed value", "2233173152"]
-    ],
-    "packages/betterer/src/require.ts:3480205399": [
-      [6, 2, 22, "Unsafe return of an any typed value", "880393137"],
-      [18, 2, 38, "Unsafe return of an any typed value", "2611709393"]
-    ],
-    "packages/extension/src/server/config.ts:3376275560": [
-      [21, 2, 59, "Unsafe return of type Promise<any> from function with return type Promise<WorkspaceConfiguration>.", "3903064458"]
     ]
   }`
 };

--- a/.betterer.ts
+++ b/.betterer.ts
@@ -1,28 +1,22 @@
-import { eslintBetterer } from '@betterer/eslint';
-import { regexpBetterer } from '@betterer/regexp';
-import { tsqueryBetterer } from '@betterer/tsquery';
-
-const WIP_LINT_TEST = [
-  '@typescript-eslint/ban-types',
-  '@typescript-eslint/restrict-template-expressions',
-  '@typescript-eslint/no-floating-promises',
-  '@typescript-eslint/no-unsafe-assignment',
-  '@typescript-eslint/no-unsafe-call',
-  '@typescript-eslint/no-unsafe-member-access',
-  '@typescript-eslint/no-unsafe-return'
-].reduce((rules, ruleName) => {
-  rules[ruleName] = eslintBetterer('./packages/**/src/**/*.{js,ts}', [ruleName, 2]).include(
-    './test/**/*.{js,ts}',
-    './*.{js,ts}'
-  );
-  return rules;
-}, {});
+import { eslint } from '@betterer/eslint';
+import { regexp } from '@betterer/regexp';
+import { tsquery } from '@betterer/tsquery';
 
 export default {
-  'no hack comments': regexpBetterer('./packages/**/src/**/*.ts', /(\/\/\s*HACK)/i),
-  'no raw console.log': tsqueryBetterer(
+  'no hack comments': regexp(/(\/\/\s*HACK)/i).include('./packages/**/src/**/*.ts'),
+
+  'no raw console.log': tsquery(
     './tsconfig.json',
     'CallExpression > PropertyAccessExpression[expression.name="console"][name.name="log"]'
   ).exclude(/logger\/src/, /betterer\/src\/reporters/),
-  ...WIP_LINT_TEST
+
+  'new eslint rules': eslint({
+    '@typescript-eslint/ban-types': 2,
+    '@typescript-eslint/restrict-template-expressions': 2,
+    '@typescript-eslint/no-floating-promises': 2,
+    '@typescript-eslint/no-unsafe-assignment': 2,
+    '@typescript-eslint/no-unsafe-call': 2,
+    '@typescript-eslint/no-unsafe-member-access': 2,
+    '@typescript-eslint/no-unsafe-return': 2
+  }).include('./packages/**/src/**/*.{js,ts}', './test/**/*.{js,ts}', './*.{js,ts}')
 };

--- a/README.md
+++ b/README.md
@@ -82,10 +82,10 @@ Isn't that neat!? ☀️
 If you want to enable a new [ESLint](https://eslint.org/) rule in your codebase, you can use the `@betterer/eslint`:
 
 ```typescript
-import { eslintBetterer } from '@betterer/eslint';
+import { eslint } from '@betterer/eslint';
 
 export default {
-  'no more debuggers': eslintBetterer('./src/**/*.ts', ['no-debugger', 'error'])
+  'no more debuggers': eslint({ 'no-debugger': 'error' }).include('./src/**/*.ts')
 };
 ```
 
@@ -94,10 +94,10 @@ export default {
 If you want to remove anything that matches a Regular Expression within your codebase, you can use `@betterer/regexp`:
 
 ```typescript
-import { regexpBetterer } from '@betterer/regexp';
+import { regexp } from '@betterer/regexp';
 
 export default {
-  'no hack comments': regexpBetterer('**/*.ts', /(\/\/\s*HACK)/i)
+  'no hack comments': regexp(/(\/\/\s*HACK)/i).include('**/*.ts')
 };
 ```
 
@@ -108,10 +108,10 @@ export default {
 If you want to remove anything that matches a [TSQuery](https://github.com/phenomnomnominal/tsquery) within your codebase, you can use `@betterer/tsquery`:
 
 ```typescript
-import { tsqueryBetterer } from '@betterer/tsquery';
+import { tsquery } from '@betterer/tsquery';
 
 export default {
-  'no raw console.log': tsqueryBetterer(
+  'no raw console.log': tsquery(
     './tsconfig.json',
     'CallExpression > PropertyAccessExpression[expression.name="console"][name.name="log"]'
   )
@@ -123,10 +123,10 @@ export default {
 If you want to enable a new [TypeScript](https://www.typescriptlang.org/) compiler option to your codebase, you can use `@betterer/typescript`:
 
 ```typescript
-import { typescriptBetterer } from '@betterer/typescript';
+import { typescript } from '@betterer/typescript';
 
 export default {
-  'stricter compilation': typescriptBetterer('./tsconfig.json', {
+  'stricter compilation': typescript('./tsconfig.json', {
     strict: true
   })
 };

--- a/packages/eslint/README.md
+++ b/packages/eslint/README.md
@@ -13,10 +13,10 @@ Use this test to incrementally introduce ESLint rules to your codebase
 ## Usage
 
 ```typescript
-import { eslintBetterer } from '@betterer/eslint';
+import { eslint } from '@betterer/eslint';
 
 export default {
-  'no more debuggers': eslintBetterer('./src/**/*.ts', ['no-debugger', 'error'])
+  'no more debuggers': eslint({ 'no-debugger': 'error' }).include('./src/**/*.ts')
 };
 ```
 
@@ -25,10 +25,10 @@ export default {
 Skip a test by calling `.skip()`:
 
 ```typescript
-import { eslintBetterer } from '@betterer/eslint';
+import { eslint } from '@betterer/eslint';
 
 export default {
-  'no more debuggers': eslintBetterer(...).skip()
+  'no more debuggers': eslint(...).skip()
 };
 ```
 
@@ -37,10 +37,10 @@ export default {
 Run a test by itself by calling `.only()`:
 
 ```typescript
-import { regexpBetterer } from '@betterer/regexp';
+import { eslint } from '@betterer/eslint';
 
 export default {
-  'no more debuggers': eslintBetterer(...).only()
+  'no more debuggers': eslint(...).only()
 };
 ```
 
@@ -49,9 +49,9 @@ export default {
 Exclude files from a test by calling `.exclude()`:
 
 ```typescript
-import { regexpBetterer } from '@betterer/regexp';
+import { eslint } from '@betterer/eslint';
 
 export default {
-  'no more debuggers': eslintBetterer(...).exclude(/excluded-file-regexp/)
+  'no more debuggers': eslint(...).exclude(/excluded-file-regexp/)
 };
 ```

--- a/packages/eslint/src/errors.ts
+++ b/packages/eslint/src/errors.ts
@@ -6,3 +6,6 @@ export const FILE_GLOB_REQUIRED = registerError(
 export const RULE_OPTIONS_REQUIRED = registerError(
   () => "For `@betterer/eslint` to work, you need to provide rule options, e.g. `['no-debugger', 'error']`. ❌"
 );
+export const RULES_OPTIONS_REQUIRED = registerError(
+  () => "For `@betterer/eslint` to work, you need to provide rule options, e.g. `{ 'no-debugger': 'error' }`. ❌"
+);

--- a/packages/eslint/src/index.ts
+++ b/packages/eslint/src/index.ts
@@ -1,1 +1,1 @@
-export { eslintBetterer } from './eslint';
+export { eslintBetterer, eslint } from './eslint';

--- a/packages/regexp/README.md
+++ b/packages/regexp/README.md
@@ -13,10 +13,10 @@ Use this test to incrementally remove RegExp matches from your codebase!
 ## Usage
 
 ```typescript
-import { regexpBetterer } from '@betterer/regexp';
+import { regexp } from '@betterer/regexp';
 
 export default {
-  'no hack comments': regexpBetterer('**/*.ts', /(\/\/\s*HACK)/i)
+  'no hack comments': regexp(/(\/\/\s*HACK)/i).include('**/*.ts')
 };
 ```
 
@@ -25,10 +25,10 @@ export default {
 Skip a test by calling `.skip()`:
 
 ```typescript
-import { regexpBetterer } from '@betterer/regexp';
+import { regexp } from '@betterer/regexp';
 
 export default {
-  'no hack comments': regexpBetterer(...).skip()
+  'no hack comments': regexp(...).skip()
 };
 ```
 
@@ -37,10 +37,10 @@ export default {
 Run a test by itself by calling `.only()`:
 
 ```typescript
-import { regexpBetterer } from '@betterer/regexp';
+import { regexp } from '@betterer/regexp';
 
 export default {
-  'no hack comments': regexpBetterer(...).only()
+  'no hack comments': regexp(...).only()
 };
 ```
 
@@ -49,9 +49,9 @@ export default {
 Exclude files from a test by calling `.exclude()`:
 
 ```typescript
-import { regexpBetterer } from '@betterer/regexp';
+import { regexp } from '@betterer/regexp';
 
 export default {
-  'no hack comments': regexpBetterer(...).exclude(/excluded-file-regexp/)
+  'no hack comments': regexp(...).exclude(/excluded-file-regexp/)
 };
 ```

--- a/packages/regexp/src/index.ts
+++ b/packages/regexp/src/index.ts
@@ -1,1 +1,1 @@
-export { regexpBetterer } from './regexp';
+export { regexpBetterer, regexp } from './regexp';

--- a/packages/tsquery/README.md
+++ b/packages/tsquery/README.md
@@ -13,10 +13,10 @@ Use this test to incrementally remove TSQuery matches from your codebase! See th
 ## Usage
 
 ```typescript
-import { tsqueryBetterer } from '@betterer/tsquery';
+import { tsquery } from '@betterer/tsquery';
 
 export default {
-  'no raw console.log': tsqueryBetterer(
+  'no raw console.log': tsquery(
     './tsconfig.json',
     'CallExpression > PropertyAccessExpression[expression.name="console"][name.name="log"]'
   )
@@ -28,10 +28,10 @@ export default {
 Skip a test by calling `.skip()`:
 
 ```typescript
-import { tsqueryBetterer } from '@betterer/tsquery';
+import { tsquery } from '@betterer/tsquery';
 
 export default {
-  'no raw console.log': tsqueryBetterer(...).skip()
+  'no raw console.log': tsquery(...).skip()
 };
 ```
 
@@ -40,10 +40,10 @@ export default {
 Run a test by itself by calling `.only()`:
 
 ```typescript
-import { tsqueryBetterer } from '@betterer/tsquery';
+import { tsquery } from '@betterer/tsquery';
 
 export default {
-  'no raw console.log': tsqueryBetterer(...).only()
+  'no raw console.log': tsquery(...).only()
 };
 ```
 
@@ -52,9 +52,9 @@ export default {
 Exclude files from a test by calling `.exclude()`:
 
 ```typescript
-import { tsqueryBetterer } from '@betterer/tsquery';
+import { tsquery } from '@betterer/tsquery';
 
 export default {
-  'no raw console.log': tsqueryBetterer(...).exclude(/excluded-file-regexp/)
+  'no raw console.log': tsquery(...).exclude(/excluded-file-regexp/)
 };
 ```

--- a/packages/tsquery/src/index.ts
+++ b/packages/tsquery/src/index.ts
@@ -1,1 +1,7 @@
-export { tsqueryBetterer } from './tsquery';
+export { tsquery } from './tsquery';
+import { tsquery } from './tsquery';
+
+/**
+ * @deprecated Use {@link @betterer/tsquery:tsquery} instead!
+ */
+export const tsqueryBetterer = tsquery;

--- a/packages/tsquery/src/tsquery.ts
+++ b/packages/tsquery/src/tsquery.ts
@@ -4,13 +4,13 @@ import {
   BettererFileIssuesRaw,
   BettererFileResolver
 } from '@betterer/betterer';
-import { tsquery } from '@phenomnomnominal/tsquery';
+import { tsquery as tsq } from '@phenomnomnominal/tsquery';
 import { promises as fs } from 'fs';
 import { SourceFile } from 'typescript';
 
 import { CONFIG_PATH_REQUIRED, QUERY_REQUIRED } from './errors';
 
-export function tsqueryBetterer(configFilePath: string, query: string): BettererFileTest {
+export function tsquery(configFilePath: string, query: string): BettererFileTest {
   if (!configFilePath) {
     throw CONFIG_PATH_REQUIRED();
   }
@@ -24,11 +24,11 @@ export function tsqueryBetterer(configFilePath: string, query: string): Betterer
   return new BettererFileTest(resolver, async () => {
     let sourceFiles: ReadonlyArray<SourceFile> = [];
 
-    const projectFiles = await resolver.validate(tsquery.projectFiles(absoluteConfigFilePath));
+    const projectFiles = await resolver.validate(tsq.projectFiles(absoluteConfigFilePath));
     sourceFiles = await Promise.all(
       projectFiles.map(async (filePath) => {
         const fileText = await fs.readFile(filePath, 'utf8');
-        const sourceFile = tsquery.ast(fileText);
+        const sourceFile = tsq.ast(fileText);
         sourceFile.fileName = filePath;
         return sourceFile;
       })
@@ -42,7 +42,7 @@ export function tsqueryBetterer(configFilePath: string, query: string): Betterer
 }
 
 function getFileMatches(query: string, sourceFile: SourceFile): BettererFileIssuesRaw {
-  return tsquery.query(sourceFile, query, { visitAllChildren: true }).map((match) => {
+  return tsq.query(sourceFile, query, { visitAllChildren: true }).map((match) => {
     return {
       message: 'TSQuery match',
       filePath: sourceFile.fileName,

--- a/packages/typescript/README.md
+++ b/packages/typescript/README.md
@@ -13,10 +13,10 @@ Use this test to incrementally introduce TypeScript configuration to your codeba
 ## Usage
 
 ```typescript
-import { typescriptBetterer } from '@betterer/typescript';
+import { typescript } from '@betterer/typescript';
 
 export default {
-  'stricter compilation': typescriptBetterer('./tsconfig.json', {
+  'stricter compilation': typescript('./tsconfig.json', {
     strict: true
   })
 };
@@ -27,10 +27,10 @@ export default {
 Skip a test by calling `.skip()`:
 
 ```typescript
-import { typescriptBetterer } from '@betterer/typescript';
+import { typescript } from '@betterer/typescript';
 
 export default {
-  'stricter compilation': typescriptBetterer(...).skip()
+  'stricter compilation': typescript(...).skip()
 };
 ```
 
@@ -39,10 +39,10 @@ export default {
 Run a test by itself by calling `.only()`:
 
 ```typescript
-import { typescriptBetterer } from '@betterer/typescript';
+import { typescript } from '@betterer/typescript';
 
 export default {
-  'stricter compilation': typescriptBetterer(...).only()
+  'stricter compilation': typescript(...).only()
 };
 ```
 
@@ -51,9 +51,9 @@ export default {
 Exclude files from a test by calling `.exclude()`:
 
 ```typescript
-import { typescriptBetterer } from '@betterer/typescript';
+import { typescript } from '@betterer/typescript';
 
 export default {
-  'stricter compilation': typescriptBetterer(...).exclude(/excluded-file-regexp/)
+  'stricter compilation': typescript(...).exclude(/excluded-file-regexp/)
 };
 ```

--- a/packages/typescript/src/index.ts
+++ b/packages/typescript/src/index.ts
@@ -1,1 +1,7 @@
-export { typescriptBetterer } from './typescript';
+export { typescript } from './typescript';
+import { typescript } from './typescript';
+
+/**
+ * @deprecated Use {@link @betterer/typescript:typescript} instead!
+ */
+export const typescriptBetterer = typescript;

--- a/packages/typescript/src/typescript.ts
+++ b/packages/typescript/src/typescript.ts
@@ -6,7 +6,7 @@ import { CONFIG_PATH_REQUIRED, COMPILER_OPTIONS_REQUIRED } from './errors';
 
 const NEW_LINE = '\n';
 
-export function typescriptBetterer(configFilePath: string, extraCompilerOptions: ts.CompilerOptions): BettererFileTest {
+export function typescript(configFilePath: string, extraCompilerOptions: ts.CompilerOptions): BettererFileTest {
   if (!configFilePath) {
     throw CONFIG_PATH_REQUIRED();
   }

--- a/test/__snapshots__/betterer-eslint.spec.ts.snap
+++ b/test/__snapshots__/betterer-eslint.spec.ts.snap
@@ -1,5 +1,145 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`betterer eslintBetterer (deprecated) should report the status of a new eslint rule 1`] = `
+"// BETTERER RESULTS V1.
+exports[\`eslint enable new rule\`] = {
+  timestamp: 0,
+  value: \`{
+    \\"src/index.ts:3201740415\\": [
+      [0, 0, 9, \\"Unexpected \\\\'debugger\\\\' statement.\\", \\"3201740415\\"]
+    ]
+  }\`
+};"
+`;
+
+exports[`betterer eslintBetterer (deprecated) should report the status of a new eslint rule 2`] = `
+Array [
+  "
+   / | /     _          _   _                     
+ '-.ooo.-'  | |__   ___| |_| |_ ___ _ __ ___ _ __ 
+---ooooo--- | '_ / / _ / __| __/ _ / '__/ _ / '__|
+ .-'ooo'-.  | |_) |  __/ |_| ||  __/ | |  __/ |   
+   / | /    |_.__/ /___|/__|/__/___|_|  /___|_|   
+ ",
+  " ☀️  betterer  info  💬  - ",
+  "running \\"eslint enable new rule\\"!",
+  " ☀️  betterer  succ  ✅  - ",
+  "\\"eslint enable new rule\\" got checked for the first time! 🎉",
+  " ☀️  betterer  info  💬  - ",
+  "1 test got checked. 🤔",
+  " ☀️  betterer  info  💬  - ",
+  "1 test got checked for the first time! 🎉",
+  "
+   / | /     _          _   _                     
+ '-.ooo.-'  | |__   ___| |_| |_ ___ _ __ ___ _ __ 
+---ooooo--- | '_ / / _ / __| __/ _ / '__/ _ / '__|
+ .-'ooo'-.  | |_) |  __/ |_| ||  __/ | |  __/ |   
+   / | /    |_.__/ /___|/__|/__/___|_|  /___|_|   
+ ",
+  " ☀️  betterer  info  💬  - ",
+  "running \\"eslint enable new rule\\"!",
+  " ☀️  betterer  warn  ⚠️  - ",
+  "\\"eslint enable new rule\\" stayed the same. 😐",
+  " ☀️  betterer  info  💬  - ",
+  "1 test got checked. 🤔",
+  " ☀️  betterer  warn  ⚠️  - ",
+  "1 test stayed the same. 😐",
+  "
+   / | /     _          _   _                     
+ '-.ooo.-'  | |__   ___| |_| |_ ___ _ __ ___ _ __ 
+---ooooo--- | '_ / / _ / __| __/ _ / '__/ _ / '__|
+ .-'ooo'-.  | |_) |  __/ |_| ||  __/ | |  __/ |   
+   / | /    |_.__/ /___|/__|/__/___|_|  /___|_|   
+ ",
+  " ☀️  betterer  info  💬  - ",
+  "running \\"eslint enable new rule\\"!",
+  " ☀️  betterer  erro  🔥  - ",
+  "\\"eslint enable new rule\\" got worse. 😔",
+  "",
+  " ☀️  betterer  warn  ⚠️  - ",
+  "1 existing issue in \\"src/index.ts\\".",
+  " ☀️  betterer  erro  🔥  - ",
+  "1 new issue in \\"src/index.ts\\":",
+  "
+   Unexpected 'debugger' statement. 
+  1 | debugger;
+> 2 | debugger;
+    | ^^^^^^^^^",
+  "",
+  "",
+  " ☀️  betterer  info  💬  - ",
+  "1 test got checked. 🤔",
+  " ☀️  betterer  erro  🔥  - ",
+  "1 test got worse. 😔",
+  "
+   / | /     _          _   _                     
+ '-.ooo.-'  | |__   ___| |_| |_ ___ _ __ ___ _ __ 
+---ooooo--- | '_ / / _ / __| __/ _ / '__/ _ / '__|
+ .-'ooo'-.  | |_) |  __/ |_| ||  __/ | |  __/ |   
+   / | /    |_.__/ /___|/__|/__/___|_|  /___|_|   
+ ",
+  " ☀️  betterer  info  💬  - ",
+  "running \\"eslint enable new rule\\"!",
+  " ☀️  betterer  succ  ✅  - ",
+  "\\"eslint enable new rule\\" met its goal! 🎉",
+  " ☀️  betterer  info  💬  - ",
+  "1 test got checked. 🤔",
+  " ☀️  betterer  succ  ✅  - ",
+  "1 test got better! 😍",
+  " ☀️  betterer  succ  ✅  - ",
+  "\\"eslint enable new rule\\" met its goal! 🎉",
+  "
+   / | /     _          _   _                     
+ '-.ooo.-'  | |__   ___| |_| |_ ___ _ __ ___ _ __ 
+---ooooo--- | '_ / / _ / __| __/ _ / '__/ _ / '__|
+ .-'ooo'-.  | |_) |  __/ |_| ||  __/ | |  __/ |   
+   / | /    |_.__/ /___|/__|/__/___|_|  /___|_|   
+ ",
+  " ☀️  betterer  info  💬  - ",
+  "running \\"eslint enable new rule\\"!",
+  " ☀️  betterer  succ  ✅  - ",
+  "\\"eslint enable new rule\\" has already met its goal! ✨",
+  " ☀️  betterer  info  💬  - ",
+  "1 test got checked. 🤔",
+  " ☀️  betterer  info  💬  - ",
+  "1 test got checked for the first time! 🎉",
+  " ☀️  betterer  succ  ✅  - ",
+  "\\"eslint enable new rule\\" met its goal! 🎉",
+]
+`;
+
+exports[`betterer eslintBetterer (deprecated) should throw if there is no globs 1`] = `
+Array [
+  "
+   / | /     _          _   _                     
+ '-.ooo.-'  | |__   ___| |_| |_ ___ _ __ ___ _ __ 
+---ooooo--- | '_ / / _ / __| __/ _ / '__/ _ / '__|
+ .-'ooo'-.  | |_) |  __/ |_| ||  __/ | |  __/ |   
+   / | /    |_.__/ /___|/__|/__/___|_|  /___|_|   
+ ",
+  " ☀️  betterer  erro  🔥  - ",
+  "could not read config from \\"<project>/fixtures/test-betterer-eslint-no-globs-deprecated/.betterer\\". 😔",
+  " ☀️  betterer  erro  🔥  - ",
+  "For \`@betterer/eslint\` to work, you need to provide a file glob, e.g. \`'./src/**/*'\`. ❌",
+]
+`;
+
+exports[`betterer eslintBetterer (deprecated) should throw if there is no rule 1`] = `
+Array [
+  "
+   / | /     _          _   _                     
+ '-.ooo.-'  | |__   ___| |_| |_ ___ _ __ ___ _ __ 
+---ooooo--- | '_ / / _ / __| __/ _ / '__/ _ / '__|
+ .-'ooo'-.  | |_) |  __/ |_| ||  __/ | |  __/ |   
+   / | /    |_.__/ /___|/__|/__/___|_|  /___|_|   
+ ",
+  " ☀️  betterer  erro  🔥  - ",
+  "could not read config from \\"<project>/fixtures/test-betterer-eslint-no-rule-deprecated/.betterer\\". 😔",
+  " ☀️  betterer  erro  🔥  - ",
+  "For \`@betterer/eslint\` to work, you need to provide rule options, e.g. \`['no-debugger', 'error']\`. ❌",
+]
+`;
+
 exports[`betterer should report the status of a new eslint rule 1`] = `
 "// BETTERER RESULTS V1.
 exports[\`eslint enable new rule\`] = {
@@ -108,23 +248,7 @@ Array [
 ]
 `;
 
-exports[`betterer should throw if there is no globs 1`] = `
-Array [
-  "
-   / | /     _          _   _                     
- '-.ooo.-'  | |__   ___| |_| |_ ___ _ __ ___ _ __ 
----ooooo--- | '_ / / _ / __| __/ _ / '__/ _ / '__|
- .-'ooo'-.  | |_) |  __/ |_| ||  __/ | |  __/ |   
-   / | /    |_.__/ /___|/__|/__/___|_|  /___|_|   
- ",
-  " ☀️  betterer  erro  🔥  - ",
-  "could not read config from \\"<project>/fixtures/test-betterer-eslint-no-globs/.betterer\\". 😔",
-  " ☀️  betterer  erro  🔥  - ",
-  "For \`@betterer/eslint\` to work, you need to provide a file glob, e.g. \`'./src/**/*'\`. ❌",
-]
-`;
-
-exports[`betterer should throw if there is no rule 1`] = `
+exports[`betterer should throw if there are no rules 1`] = `
 Array [
   "
    / | /     _          _   _                     
@@ -136,6 +260,6 @@ Array [
   " ☀️  betterer  erro  🔥  - ",
   "could not read config from \\"<project>/fixtures/test-betterer-eslint-no-rule/.betterer\\". 😔",
   " ☀️  betterer  erro  🔥  - ",
-  "For \`@betterer/eslint\` to work, you need to provide rule options, e.g. \`['no-debugger', 'error']\`. ❌",
+  "For \`@betterer/eslint\` to work, you need to provide rule options, e.g. \`{ 'no-debugger': 'error' }\`. ❌",
 ]
 `;

--- a/test/__snapshots__/betterer-regexp.spec.ts.snap
+++ b/test/__snapshots__/betterer-regexp.spec.ts.snap
@@ -1,5 +1,145 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`betterer regexpBetterer (deprecated) should report the existence of RegExp matches 1`] = `
+"// BETTERER RESULTS V1.
+exports[\`regexp no hack comments\`] = {
+  timestamp: 0,
+  value: \`{
+    \\"src/index.ts:4126639614\\": [
+      [0, 0, 7, \\"RegExp match\\", \\"645651780\\"]
+    ]
+  }\`
+};"
+`;
+
+exports[`betterer regexpBetterer (deprecated) should report the existence of RegExp matches 2`] = `
+Array [
+  "
+   / | /     _          _   _                     
+ '-.ooo.-'  | |__   ___| |_| |_ ___ _ __ ___ _ __ 
+---ooooo--- | '_ / / _ / __| __/ _ / '__/ _ / '__|
+ .-'ooo'-.  | |_) |  __/ |_| ||  __/ | |  __/ |   
+   / | /    |_.__/ /___|/__|/__/___|_|  /___|_|   
+ ",
+  " ☀️  betterer  info  💬  - ",
+  "running \\"regexp no hack comments\\"!",
+  " ☀️  betterer  succ  ✅  - ",
+  "\\"regexp no hack comments\\" got checked for the first time! 🎉",
+  " ☀️  betterer  info  💬  - ",
+  "1 test got checked. 🤔",
+  " ☀️  betterer  info  💬  - ",
+  "1 test got checked for the first time! 🎉",
+  "
+   / | /     _          _   _                     
+ '-.ooo.-'  | |__   ___| |_| |_ ___ _ __ ___ _ __ 
+---ooooo--- | '_ / / _ / __| __/ _ / '__/ _ / '__|
+ .-'ooo'-.  | |_) |  __/ |_| ||  __/ | |  __/ |   
+   / | /    |_.__/ /___|/__|/__/___|_|  /___|_|   
+ ",
+  " ☀️  betterer  info  💬  - ",
+  "running \\"regexp no hack comments\\"!",
+  " ☀️  betterer  warn  ⚠️  - ",
+  "\\"regexp no hack comments\\" stayed the same. 😐",
+  " ☀️  betterer  info  💬  - ",
+  "1 test got checked. 🤔",
+  " ☀️  betterer  warn  ⚠️  - ",
+  "1 test stayed the same. 😐",
+  "
+   / | /     _          _   _                     
+ '-.ooo.-'  | |__   ___| |_| |_ ___ _ __ ___ _ __ 
+---ooooo--- | '_ / / _ / __| __/ _ / '__/ _ / '__|
+ .-'ooo'-.  | |_) |  __/ |_| ||  __/ | |  __/ |   
+   / | /    |_.__/ /___|/__|/__/___|_|  /___|_|   
+ ",
+  " ☀️  betterer  info  💬  - ",
+  "running \\"regexp no hack comments\\"!",
+  " ☀️  betterer  erro  🔥  - ",
+  "\\"regexp no hack comments\\" got worse. 😔",
+  "",
+  " ☀️  betterer  warn  ⚠️  - ",
+  "1 existing issue in \\"src/index.ts\\".",
+  " ☀️  betterer  erro  🔥  - ",
+  "1 new issue in \\"src/index.ts\\":",
+  "
+   RegExp match 
+  1 | // HACK:
+> 2 | // HACK:
+    | ^^^^^^^",
+  "",
+  "",
+  " ☀️  betterer  info  💬  - ",
+  "1 test got checked. 🤔",
+  " ☀️  betterer  erro  🔥  - ",
+  "1 test got worse. 😔",
+  "
+   / | /     _          _   _                     
+ '-.ooo.-'  | |__   ___| |_| |_ ___ _ __ ___ _ __ 
+---ooooo--- | '_ / / _ / __| __/ _ / '__/ _ / '__|
+ .-'ooo'-.  | |_) |  __/ |_| ||  __/ | |  __/ |   
+   / | /    |_.__/ /___|/__|/__/___|_|  /___|_|   
+ ",
+  " ☀️  betterer  info  💬  - ",
+  "running \\"regexp no hack comments\\"!",
+  " ☀️  betterer  succ  ✅  - ",
+  "\\"regexp no hack comments\\" met its goal! 🎉",
+  " ☀️  betterer  info  💬  - ",
+  "1 test got checked. 🤔",
+  " ☀️  betterer  succ  ✅  - ",
+  "1 test got better! 😍",
+  " ☀️  betterer  succ  ✅  - ",
+  "\\"regexp no hack comments\\" met its goal! 🎉",
+  "
+   / | /     _          _   _                     
+ '-.ooo.-'  | |__   ___| |_| |_ ___ _ __ ___ _ __ 
+---ooooo--- | '_ / / _ / __| __/ _ / '__/ _ / '__|
+ .-'ooo'-.  | |_) |  __/ |_| ||  __/ | |  __/ |   
+   / | /    |_.__/ /___|/__|/__/___|_|  /___|_|   
+ ",
+  " ☀️  betterer  info  💬  - ",
+  "running \\"regexp no hack comments\\"!",
+  " ☀️  betterer  succ  ✅  - ",
+  "\\"regexp no hack comments\\" has already met its goal! ✨",
+  " ☀️  betterer  info  💬  - ",
+  "1 test got checked. 🤔",
+  " ☀️  betterer  info  💬  - ",
+  "1 test got checked for the first time! 🎉",
+  " ☀️  betterer  succ  ✅  - ",
+  "\\"regexp no hack comments\\" met its goal! 🎉",
+]
+`;
+
+exports[`betterer regexpBetterer (deprecated) should throw if there is no globs 1`] = `
+Array [
+  "
+   / | /     _          _   _                     
+ '-.ooo.-'  | |__   ___| |_| |_ ___ _ __ ___ _ __ 
+---ooooo--- | '_ / / _ / __| __/ _ / '__/ _ / '__|
+ .-'ooo'-.  | |_) |  __/ |_| ||  __/ | |  __/ |   
+   / | /    |_.__/ /___|/__|/__/___|_|  /___|_|   
+ ",
+  " ☀️  betterer  erro  🔥  - ",
+  "could not read config from \\"<project>/fixtures/test-betterer-regexp-no-globs-deprecated/.betterer\\". 😔",
+  " ☀️  betterer  erro  🔥  - ",
+  "For \`@betterer/regexp\` to work, you need to provide a file glob, e.g. \`'./src/**/*'\`. ❌",
+]
+`;
+
+exports[`betterer regexpBetterer (deprecated) should throw if there is no regexp 1`] = `
+Array [
+  "
+   / | /     _          _   _                     
+ '-.ooo.-'  | |__   ___| |_| |_ ___ _ __ ___ _ __ 
+---ooooo--- | '_ / / _ / __| __/ _ / '__/ _ / '__|
+ .-'ooo'-.  | |_) |  __/ |_| ||  __/ | |  __/ |   
+   / | /    |_.__/ /___|/__|/__/___|_|  /___|_|   
+ ",
+  " ☀️  betterer  erro  🔥  - ",
+  "could not read config from \\"<project>/fixtures/test-betterer-regexp-no-regexp-deprecated/.betterer\\". 😔",
+  " ☀️  betterer  erro  🔥  - ",
+  "For \`@betterer/regexp\` to work, you need to provide a RegExp, e.g. \`/^foo$/\`. ❌",
+]
+`;
+
 exports[`betterer should report the existence of RegExp matches 1`] = `
 "// BETTERER RESULTS V1.
 exports[\`regexp no hack comments\`] = {
@@ -105,22 +245,6 @@ Array [
   "1 test got checked for the first time! 🎉",
   " ☀️  betterer  succ  ✅  - ",
   "\\"regexp no hack comments\\" met its goal! 🎉",
-]
-`;
-
-exports[`betterer should throw if there is no globs 1`] = `
-Array [
-  "
-   / | /     _          _   _                     
- '-.ooo.-'  | |__   ___| |_| |_ ___ _ __ ___ _ __ 
----ooooo--- | '_ / / _ / __| __/ _ / '__/ _ / '__|
- .-'ooo'-.  | |_) |  __/ |_| ||  __/ | |  __/ |   
-   / | /    |_.__/ /___|/__|/__/___|_|  /___|_|   
- ",
-  " ☀️  betterer  erro  🔥  - ",
-  "could not read config from \\"<project>/fixtures/test-betterer-regexp-no-globs/.betterer\\". 😔",
-  " ☀️  betterer  erro  🔥  - ",
-  "For \`@betterer/regexp\` to work, you need to provide a file glob, e.g. \`'./src/**/*'\`. ❌",
 ]
 `;
 

--- a/test/__snapshots__/betterer-tsquery.spec.ts.snap
+++ b/test/__snapshots__/betterer-tsquery.spec.ts.snap
@@ -139,3 +139,143 @@ Array [
   "For \`@betterer/tsquery\` to work, you need to provide a query, e.g. \`'CallExpression > PropertyAccessExpression'\`. ❌",
 ]
 `;
+
+exports[`betterer tsqueryBetterer (deprecated) should report the existence of TSQuery matches 1`] = `
+"// BETTERER RESULTS V1.
+exports[\`tsquery no raw console.log\`] = {
+  timestamp: 0,
+  value: \`{
+    \\"src/index.ts:4087252068\\": [
+      [0, 0, 11, \\"TSQuery match\\", \\"3870399096\\"]
+    ]
+  }\`
+};"
+`;
+
+exports[`betterer tsqueryBetterer (deprecated) should report the existence of TSQuery matches 2`] = `
+Array [
+  "
+   / | /     _          _   _                     
+ '-.ooo.-'  | |__   ___| |_| |_ ___ _ __ ___ _ __ 
+---ooooo--- | '_ / / _ / __| __/ _ / '__/ _ / '__|
+ .-'ooo'-.  | |_) |  __/ |_| ||  __/ | |  __/ |   
+   / | /    |_.__/ /___|/__|/__/___|_|  /___|_|   
+ ",
+  " ☀️  betterer  info  💬  - ",
+  "running \\"tsquery no raw console.log\\"!",
+  " ☀️  betterer  succ  ✅  - ",
+  "\\"tsquery no raw console.log\\" got checked for the first time! 🎉",
+  " ☀️  betterer  info  💬  - ",
+  "1 test got checked. 🤔",
+  " ☀️  betterer  info  💬  - ",
+  "1 test got checked for the first time! 🎉",
+  "
+   / | /     _          _   _                     
+ '-.ooo.-'  | |__   ___| |_| |_ ___ _ __ ___ _ __ 
+---ooooo--- | '_ / / _ / __| __/ _ / '__/ _ / '__|
+ .-'ooo'-.  | |_) |  __/ |_| ||  __/ | |  __/ |   
+   / | /    |_.__/ /___|/__|/__/___|_|  /___|_|   
+ ",
+  " ☀️  betterer  info  💬  - ",
+  "running \\"tsquery no raw console.log\\"!",
+  " ☀️  betterer  warn  ⚠️  - ",
+  "\\"tsquery no raw console.log\\" stayed the same. 😐",
+  " ☀️  betterer  info  💬  - ",
+  "1 test got checked. 🤔",
+  " ☀️  betterer  warn  ⚠️  - ",
+  "1 test stayed the same. 😐",
+  "
+   / | /     _          _   _                     
+ '-.ooo.-'  | |__   ___| |_| |_ ___ _ __ ___ _ __ 
+---ooooo--- | '_ / / _ / __| __/ _ / '__/ _ / '__|
+ .-'ooo'-.  | |_) |  __/ |_| ||  __/ | |  __/ |   
+   / | /    |_.__/ /___|/__|/__/___|_|  /___|_|   
+ ",
+  " ☀️  betterer  info  💬  - ",
+  "running \\"tsquery no raw console.log\\"!",
+  " ☀️  betterer  erro  🔥  - ",
+  "\\"tsquery no raw console.log\\" got worse. 😔",
+  "",
+  " ☀️  betterer  warn  ⚠️  - ",
+  "1 existing issue in \\"src/index.ts\\".",
+  " ☀️  betterer  erro  🔥  - ",
+  "1 new issue in \\"src/index.ts\\":",
+  "
+   TSQuery match 
+  1 | console.log('foo');
+> 2 | console.log('foo');
+    | ^^^^^^^^^^^",
+  "",
+  "",
+  " ☀️  betterer  info  💬  - ",
+  "1 test got checked. 🤔",
+  " ☀️  betterer  erro  🔥  - ",
+  "1 test got worse. 😔",
+  "
+   / | /     _          _   _                     
+ '-.ooo.-'  | |__   ___| |_| |_ ___ _ __ ___ _ __ 
+---ooooo--- | '_ / / _ / __| __/ _ / '__/ _ / '__|
+ .-'ooo'-.  | |_) |  __/ |_| ||  __/ | |  __/ |   
+   / | /    |_.__/ /___|/__|/__/___|_|  /___|_|   
+ ",
+  " ☀️  betterer  info  💬  - ",
+  "running \\"tsquery no raw console.log\\"!",
+  " ☀️  betterer  succ  ✅  - ",
+  "\\"tsquery no raw console.log\\" met its goal! 🎉",
+  " ☀️  betterer  info  💬  - ",
+  "1 test got checked. 🤔",
+  " ☀️  betterer  succ  ✅  - ",
+  "1 test got better! 😍",
+  " ☀️  betterer  succ  ✅  - ",
+  "\\"tsquery no raw console.log\\" met its goal! 🎉",
+  "
+   / | /     _          _   _                     
+ '-.ooo.-'  | |__   ___| |_| |_ ___ _ __ ___ _ __ 
+---ooooo--- | '_ / / _ / __| __/ _ / '__/ _ / '__|
+ .-'ooo'-.  | |_) |  __/ |_| ||  __/ | |  __/ |   
+   / | /    |_.__/ /___|/__|/__/___|_|  /___|_|   
+ ",
+  " ☀️  betterer  info  💬  - ",
+  "running \\"tsquery no raw console.log\\"!",
+  " ☀️  betterer  succ  ✅  - ",
+  "\\"tsquery no raw console.log\\" has already met its goal! ✨",
+  " ☀️  betterer  info  💬  - ",
+  "1 test got checked. 🤔",
+  " ☀️  betterer  info  💬  - ",
+  "1 test got checked for the first time! 🎉",
+  " ☀️  betterer  succ  ✅  - ",
+  "\\"tsquery no raw console.log\\" met its goal! 🎉",
+]
+`;
+
+exports[`betterer tsqueryBetterer (deprecated) should throw if there is no configFilePath 1`] = `
+Array [
+  "
+   / | /     _          _   _                     
+ '-.ooo.-'  | |__   ___| |_| |_ ___ _ __ ___ _ __ 
+---ooooo--- | '_ / / _ / __| __/ _ / '__/ _ / '__|
+ .-'ooo'-.  | |_) |  __/ |_| ||  __/ | |  __/ |   
+   / | /    |_.__/ /___|/__|/__/___|_|  /___|_|   
+ ",
+  " ☀️  betterer  erro  🔥  - ",
+  "could not read config from \\"<project>/fixtures/test-betterer-tsquery-no-config-file-path-deprecated/.betterer\\". 😔",
+  " ☀️  betterer  erro  🔥  - ",
+  "For \`@betterer/tsquery\` to work, you need to provide the path to a tsconfig.json file, e.g. \`'./tsconfig.json'\`. ❌",
+]
+`;
+
+exports[`betterer tsqueryBetterer (deprecated) should throw if there is no query 1`] = `
+Array [
+  "
+   / | /     _          _   _                     
+ '-.ooo.-'  | |__   ___| |_| |_ ___ _ __ ___ _ __ 
+---ooooo--- | '_ / / _ / __| __/ _ / '__/ _ / '__|
+ .-'ooo'-.  | |_) |  __/ |_| ||  __/ | |  __/ |   
+   / | /    |_.__/ /___|/__|/__/___|_|  /___|_|   
+ ",
+  " ☀️  betterer  erro  🔥  - ",
+  "could not read config from \\"<project>/fixtures/test-betterer-tsquery-no-query-deprecated/.betterer\\". 😔",
+  " ☀️  betterer  erro  🔥  - ",
+  "For \`@betterer/tsquery\` to work, you need to provide a query, e.g. \`'CallExpression > PropertyAccessExpression'\`. ❌",
+]
+`;

--- a/test/__snapshots__/betterer-typescript.spec.ts.snap
+++ b/test/__snapshots__/betterer-typescript.spec.ts.snap
@@ -140,3 +140,144 @@ Array [
   "For \`@betterer/typescript\` to work, you need to provide compiler options, e.g. \`{ strict: true }\`. ❌",
 ]
 `;
+
+exports[`betterer typescriptBetterer (deprecated) should report the status of the TypeScript compiler 1`] = `
+"// BETTERER RESULTS V1.
+exports[\`typescript use strict mode\`] = {
+  timestamp: 0,
+  value: \`{
+    \\"src/index.ts:1499252024\\": [
+      [2, 12, 1, \\"The left-hand side of an arithmetic operation must be of type \\\\'any\\\\', \\\\'number\\\\', \\\\'bigint\\\\' or an enum type.\\", \\"177604\\"]
+    ]
+  }\`
+};"
+`;
+
+exports[`betterer typescriptBetterer (deprecated) should report the status of the TypeScript compiler 2`] = `
+Array [
+  "
+   / | /     _          _   _                     
+ '-.ooo.-'  | |__   ___| |_| |_ ___ _ __ ___ _ __ 
+---ooooo--- | '_ / / _ / __| __/ _ / '__/ _ / '__|
+ .-'ooo'-.  | |_) |  __/ |_| ||  __/ | |  __/ |   
+   / | /    |_.__/ /___|/__|/__/___|_|  /___|_|   
+ ",
+  " ☀️  betterer  info  💬  - ",
+  "running \\"typescript use strict mode\\"!",
+  " ☀️  betterer  succ  ✅  - ",
+  "\\"typescript use strict mode\\" got checked for the first time! 🎉",
+  " ☀️  betterer  info  💬  - ",
+  "1 test got checked. 🤔",
+  " ☀️  betterer  info  💬  - ",
+  "1 test got checked for the first time! 🎉",
+  "
+   / | /     _          _   _                     
+ '-.ooo.-'  | |__   ___| |_| |_ ___ _ __ ___ _ __ 
+---ooooo--- | '_ / / _ / __| __/ _ / '__/ _ / '__|
+ .-'ooo'-.  | |_) |  __/ |_| ||  __/ | |  __/ |   
+   / | /    |_.__/ /___|/__|/__/___|_|  /___|_|   
+ ",
+  " ☀️  betterer  info  💬  - ",
+  "running \\"typescript use strict mode\\"!",
+  " ☀️  betterer  warn  ⚠️  - ",
+  "\\"typescript use strict mode\\" stayed the same. 😐",
+  " ☀️  betterer  info  💬  - ",
+  "1 test got checked. 🤔",
+  " ☀️  betterer  warn  ⚠️  - ",
+  "1 test stayed the same. 😐",
+  "
+   / | /     _          _   _                     
+ '-.ooo.-'  | |__   ___| |_| |_ ___ _ __ ___ _ __ 
+---ooooo--- | '_ / / _ / __| __/ _ / '__/ _ / '__|
+ .-'ooo'-.  | |_) |  __/ |_| ||  __/ | |  __/ |   
+   / | /    |_.__/ /___|/__|/__/___|_|  /___|_|   
+ ",
+  " ☀️  betterer  info  💬  - ",
+  "running \\"typescript use strict mode\\"!",
+  " ☀️  betterer  erro  🔥  - ",
+  "\\"typescript use strict mode\\" got worse. 😔",
+  "",
+  " ☀️  betterer  warn  ⚠️  - ",
+  "1 existing issue in \\"src/index.ts\\".",
+  " ☀️  betterer  erro  🔥  - ",
+  "1 new issue in \\"src/index.ts\\":",
+  "
+   The right-hand side of an arithmetic operation must be of type 'any', 'number', 'bigint' or an enum type. 
+  1 | const a = 'a';
+  2 | const one = 1;
+> 3 | console.log(a * one, one * a);
+    |                            ^",
+  "",
+  "",
+  " ☀️  betterer  info  💬  - ",
+  "1 test got checked. 🤔",
+  " ☀️  betterer  erro  🔥  - ",
+  "1 test got worse. 😔",
+  "
+   / | /     _          _   _                     
+ '-.ooo.-'  | |__   ___| |_| |_ ___ _ __ ___ _ __ 
+---ooooo--- | '_ / / _ / __| __/ _ / '__/ _ / '__|
+ .-'ooo'-.  | |_) |  __/ |_| ||  __/ | |  __/ |   
+   / | /    |_.__/ /___|/__|/__/___|_|  /___|_|   
+ ",
+  " ☀️  betterer  info  💬  - ",
+  "running \\"typescript use strict mode\\"!",
+  " ☀️  betterer  succ  ✅  - ",
+  "\\"typescript use strict mode\\" met its goal! 🎉",
+  " ☀️  betterer  info  💬  - ",
+  "1 test got checked. 🤔",
+  " ☀️  betterer  succ  ✅  - ",
+  "1 test got better! 😍",
+  " ☀️  betterer  succ  ✅  - ",
+  "\\"typescript use strict mode\\" met its goal! 🎉",
+  "
+   / | /     _          _   _                     
+ '-.ooo.-'  | |__   ___| |_| |_ ___ _ __ ___ _ __ 
+---ooooo--- | '_ / / _ / __| __/ _ / '__/ _ / '__|
+ .-'ooo'-.  | |_) |  __/ |_| ||  __/ | |  __/ |   
+   / | /    |_.__/ /___|/__|/__/___|_|  /___|_|   
+ ",
+  " ☀️  betterer  info  💬  - ",
+  "running \\"typescript use strict mode\\"!",
+  " ☀️  betterer  succ  ✅  - ",
+  "\\"typescript use strict mode\\" has already met its goal! ✨",
+  " ☀️  betterer  info  💬  - ",
+  "1 test got checked. 🤔",
+  " ☀️  betterer  info  💬  - ",
+  "1 test got checked for the first time! 🎉",
+  " ☀️  betterer  succ  ✅  - ",
+  "\\"typescript use strict mode\\" met its goal! 🎉",
+]
+`;
+
+exports[`betterer typescriptBetterer (deprecated) should throw if there is no configFilePath 1`] = `
+Array [
+  "
+   / | /     _          _   _                     
+ '-.ooo.-'  | |__   ___| |_| |_ ___ _ __ ___ _ __ 
+---ooooo--- | '_ / / _ / __| __/ _ / '__/ _ / '__|
+ .-'ooo'-.  | |_) |  __/ |_| ||  __/ | |  __/ |   
+   / | /    |_.__/ /___|/__|/__/___|_|  /___|_|   
+ ",
+  " ☀️  betterer  erro  🔥  - ",
+  "could not read config from \\"<project>/fixtures/test-betterer-typescript-no-config-file-path-deprecated/.betterer\\". 😔",
+  " ☀️  betterer  erro  🔥  - ",
+  "For \`@betterer/typescript\` to work, you need to provide the path to a tsconfig.json file, e.g. \`'./tsconfig.json'\`. ❌",
+]
+`;
+
+exports[`betterer typescriptBetterer (deprecated) should throw if there is no extraCompilerOptions 1`] = `
+Array [
+  "
+   / | /     _          _   _                     
+ '-.ooo.-'  | |__   ___| |_| |_ ___ _ __ ___ _ __ 
+---ooooo--- | '_ / / _ / __| __/ _ / '__/ _ / '__|
+ .-'ooo'-.  | |_) |  __/ |_| ||  __/ | |  __/ |   
+   / | /    |_.__/ /___|/__|/__/___|_|  /___|_|   
+ ",
+  " ☀️  betterer  erro  🔥  - ",
+  "could not read config from \\"<project>/fixtures/test-betterer-typescript-no-compiler-options-deprecated/.betterer\\". 😔",
+  " ☀️  betterer  erro  🔥  - ",
+  "For \`@betterer/typescript\` to work, you need to provide compiler options, e.g. \`{ strict: true }\`. ❌",
+]
+`;

--- a/test/betterer-better.spec.ts
+++ b/test/betterer-better.spec.ts
@@ -51,20 +51,20 @@ module.exports = {
   it('should work when a test changes and makes the results better', async () => {
     const { logs, paths, readFile, cleanup, resolve } = await createFixture('test-betterer-better-change-test', {
       '.betterer.ts': `
-import { tsqueryBetterer } from '@betterer/tsquery';
+import { tsquery } from '@betterer/tsquery';
 
 export default {
-  'no raw console calls': tsqueryBetterer(
+  'no raw console calls': tsquery(
     './tsconfig.json',
     'CallExpression > PropertyAccessExpression[expression.name="console"]'
   )
 };  
       `,
       '.betterer.changed.ts': `
-import { tsqueryBetterer } from '@betterer/tsquery';
+import { tsquery } from '@betterer/tsquery';
 
 export default {
-  'no raw console calls': tsqueryBetterer(
+  'no raw console calls': tsquery(
     './tsconfig.json',
     'CallExpression > PropertyAccessExpression[expression.name="console"][name.name="log"]'
   )

--- a/test/betterer-eslint-complex.spec.ts
+++ b/test/betterer-eslint-complex.spec.ts
@@ -6,10 +6,10 @@ describe('betterer', () => {
   it('should report the status of a new eslint rule with a complex set up', async () => {
     const { logs, paths, readFile, cleanup, resolve, writeFile } = await createFixture('test-betterer-eslint-complex', {
       '.betterer.ts': `
-import { eslintBetterer } from '@betterer/eslint';
+import { eslint } from '@betterer/eslint';
 
 export default {
-  'eslint enable no-debugger rule': eslintBetterer('./src/**/*.ts', ['no-debugger', 'error'])
+  'eslint enable no-debugger rule': eslint({ 'no-debugger': 'error' }).include('./src/**/*.ts')
 };
       `,
       '.eslintrc.js': `

--- a/test/betterer-eslint-options.spec.ts
+++ b/test/betterer-eslint-options.spec.ts
@@ -6,19 +6,18 @@ describe('betterer', () => {
   it('should handlex complex eslint rule options', async () => {
     const { logs, paths, readFile, cleanup, resolve, writeFile } = await createFixture('test-betterer-eslint-options', {
       '.betterer.ts': `
-import { eslintBetterer } from '@betterer/eslint';
+import { eslint } from '@betterer/eslint';
 
 export default {
-  'eslint enable complex rule': eslintBetterer('./src/**/*.ts', [
-    'no-restricted-syntax',
-    [
+  'eslint enable complex rule': eslint({ 
+    'no-restricted-syntax': [
       'error',
       {
         selector: 'ExportDefaultDeclaration',
         message: 'Prefer named exports'
       }
     ]
-  ])
+  }).include('./src/**/*.ts')
 };
       `,
       '.eslintrc.js': `

--- a/test/betterer-eslint.spec.ts
+++ b/test/betterer-eslint.spec.ts
@@ -6,10 +6,10 @@ describe('betterer', () => {
   it('should report the status of a new eslint rule', async () => {
     const { logs, paths, readFile, cleanup, resolve, writeFile } = await createFixture('test-betterer-eslint', {
       '.betterer.js': `
-const { eslintBetterer } = require('@betterer/eslint');
+const { eslint } = require('@betterer/eslint');
 
 module.exports = {
-  'eslint enable new rule': eslintBetterer(['./src/**/*.ts'], ['no-debugger', 'error'])
+  'eslint enable new rule': eslint({ 'no-debugger': 'error' }).include('./src/**/*.ts')
 };      
       `,
       '.eslintrc.js': `
@@ -81,14 +81,14 @@ module.exports = {
     await cleanup();
   });
 
-  it('should throw if there is no globs', async () => {
-    const { paths, logs, cleanup } = await createFixture('test-betterer-eslint-no-globs', {
+  it('should throw if there are no rules', async () => {
+    const { paths, logs, cleanup } = await createFixture('test-betterer-eslint-no-rule', {
       '.betterer.js': `
-const { eslintBetterer } = require('@betterer/eslint');
+const { eslint } = require('@betterer/eslint');
 
 module.exports = {
-  'eslint enable complex rule': eslintBetterer()
-};
+  'eslint enable complex rule': eslint().include('./src/**/*.ts')
+};      
       `
     });
 
@@ -102,24 +102,128 @@ module.exports = {
     await cleanup();
   });
 
-  it('should throw if there is no rule', async () => {
-    const { paths, logs, cleanup } = await createFixture('test-betterer-eslint-no-rule', {
-      '.betterer.js': `
+  describe('eslintBetterer (deprecated)', () => {
+    it('should report the status of a new eslint rule', async () => {
+      const { logs, paths, readFile, cleanup, resolve, writeFile } = await createFixture(
+        'test-betterer-eslint-deprecated',
+        {
+          '.betterer.js': `
+  const { eslint } = require('@betterer/eslint');
+  
+  module.exports = {
+    'eslint enable new rule': eslint({ 'no-debugger': 'error' }).include('./src/**/*.ts')
+  };      
+        `,
+          '.eslintrc.js': `
+  const path = require('path');
+  
+  module.exports = {
+    parser: '@typescript-eslint/parser',
+    parserOptions: {
+      ecmaVersion: 2018,
+      project: path.resolve(__dirname, './tsconfig.json'),
+      sourceType: 'module'
+    },
+    plugins: ['@typescript-eslint'],
+    extends: [
+      'eslint:recommended',
+      'plugin:@typescript-eslint/eslint-recommended',
+      'plugin:@typescript-eslint/recommended',
+      'plugin:@typescript-eslint/recommended-requiring-type-checking'
+    ],
+    rules: {
+      'no-debugger': 1
+    }
+  };
+        `,
+          'tsconfig.json': `
+  {
+    "extends": "../../tsconfig.json",
+    "include": ["./src/**/*", "./.betterer.js", "./.eslintrc.js"]
+  }
+        `
+        }
+      );
+
+      const configPaths = [paths.config];
+      const resultsPath = paths.results;
+      const indexPath = resolve('./src/index.ts');
+
+      await writeFile(indexPath, `debugger;`);
+
+      const newTestRun = await betterer({ configPaths, resultsPath });
+
+      expect(newTestRun.new).toEqual(['eslint enable new rule']);
+
+      const sameTestRun = await betterer({ configPaths, resultsPath });
+
+      expect(sameTestRun.same).toEqual(['eslint enable new rule']);
+
+      await writeFile(indexPath, `debugger;\ndebugger;`);
+
+      const worseTestRun = await betterer({ configPaths, resultsPath });
+
+      expect(worseTestRun.worse).toEqual(['eslint enable new rule']);
+
+      const result = await readFile(resultsPath);
+
+      expect(result).toMatchSnapshot();
+
+      await writeFile(indexPath, '');
+
+      const betterTestRun = await betterer({ configPaths, resultsPath });
+
+      expect(betterTestRun.better).toEqual(['eslint enable new rule']);
+
+      const completedTestRun = await betterer({ configPaths, resultsPath });
+
+      expect(completedTestRun.completed).toEqual(['eslint enable new rule']);
+
+      expect(logs).toMatchSnapshot();
+
+      await cleanup();
+    });
+
+    it('should throw if there is no globs', async () => {
+      const { paths, logs, cleanup } = await createFixture('test-betterer-eslint-no-globs-deprecated', {
+        '.betterer.js': `
 const { eslintBetterer } = require('@betterer/eslint');
 
 module.exports = {
-  'eslint enable complex rule': eslintBetterer('./src/**/*.ts')
-};      
-      `
+  'eslint': eslintBetterer()
+};
+        `
+      });
+
+      const configPaths = [paths.config];
+      const resultsPath = paths.results;
+
+      await expect(async () => await betterer({ configPaths, resultsPath })).rejects.toThrow();
+
+      expect(logs).toMatchSnapshot();
+
+      await cleanup();
     });
 
-    const configPaths = [paths.config];
-    const resultsPath = paths.results;
+    it('should throw if there is no rule', async () => {
+      const { paths, logs, cleanup } = await createFixture('test-betterer-eslint-no-rule-deprecated', {
+        '.betterer.js': `
+const { eslintBetterer } = require('@betterer/eslint');
 
-    await expect(async () => await betterer({ configPaths, resultsPath })).rejects.toThrow();
+module.exports = {
+  'eslint': eslintBetterer('./src/**/*.ts')
+};      
+        `
+      });
 
-    expect(logs).toMatchSnapshot();
+      const configPaths = [paths.config];
+      const resultsPath = paths.results;
 
-    await cleanup();
+      await expect(async () => await betterer({ configPaths, resultsPath })).rejects.toThrow();
+
+      expect(logs).toMatchSnapshot();
+
+      await cleanup();
+    });
   });
 });

--- a/test/betterer-exclude.spec.ts
+++ b/test/betterer-exclude.spec.ts
@@ -6,17 +6,17 @@ describe('betterer', () => {
   it('should exclude specific files from results', async () => {
     const { logs, paths, readFile, cleanup, resolve, writeFile } = await createFixture('test-betterer-exclude', {
       '.betterer.ts': `
-import { regexpBetterer } from '@betterer/regexp';
+import { regexp } from '@betterer/regexp';
 
 export default {
-  'regexp no hack comments': regexpBetterer('./src/**/*.ts', /(\\/\\/\\s*HACK)/i)
+  'regexp no hack comments': regexp(/(\\/\\/\\s*HACK)/i).include('./src/**/*.ts')
 };      
       `,
       '.betterer.exclude.ts': `
-import { regexpBetterer } from '@betterer/regexp';
+import { regexp } from '@betterer/regexp';
 
 export default {
-  'regexp no hack comments': regexpBetterer(['./src/**/*.ts'], /(\\/\\/\\s*HACK)/i).exclude(/exclude.ts/)
+  'regexp no hack comments': regexp(/(\\/\\/\\s*HACK)/i).include('./src/**/*.ts').exclude(/exclude.ts/)
 };      
       `
     });

--- a/test/betterer-only.spec.ts
+++ b/test/betterer-only.spec.ts
@@ -7,7 +7,7 @@ describe('betterer', () => {
     const { logs, paths, readFile, cleanup, resolve, writeFile } = await createFixture('test-betterer-only', {
       '.betterer.only.ts': `
 import { bigger } from '@betterer/constraints';
-import { regexpBetterer } from '@betterer/regexp';
+import { regexp } from '@betterer/regexp';
 
 export default {
   'test 1': {
@@ -23,12 +23,12 @@ export default {
     test: () => Date.now(),
     constraint: bigger
   },
-  'test 4': regexpBetterer('./src/**/*.ts', /(\\/\\/\\s*HACK)/i).only()
+  'test 4': regexp(/(\\/\\/\\s*HACK)/i).include('./src/**/*.ts').only()
 };
         `,
       '.betterer.ts': `
 import { bigger } from '@betterer/constraints';
-import { regexpBetterer } from '@betterer/regexp';
+import { regexp } from '@betterer/regexp';
 
 export default {
   'test 1': {
@@ -43,7 +43,7 @@ export default {
     test: () => Date.now(),
     constraint: bigger
   },
-  'test 4': regexpBetterer('./src/**/*.ts', /(\\/\\/\\s*HACK)/i)
+  'test 4': regexp(/(\\/\\/\\s*HACK)/i).include('./src/**/*.ts')
 };    
       `
     });

--- a/test/betterer-same.spec.ts
+++ b/test/betterer-same.spec.ts
@@ -52,10 +52,10 @@ const one = 1;
 console.log(a * one);
       `,
         '.betterer.ts': `
-import { typescriptBetterer } from '@betterer/typescript';
+import { typescript } from '@betterer/typescript';
 
 export default {
-  'typescript use strict mode': typescriptBetterer('./tsconfig.json', {
+  'typescript use strict mode': typescript('./tsconfig.json', {
     strict: true
   })
 };    
@@ -115,10 +115,10 @@ const one = 1;
 console.log(a * one);
       `,
       '.betterer.ts': `
-import { typescriptBetterer } from '@betterer/typescript';
+import { typescript } from '@betterer/typescript';
 
 export default {
-  'typescript use strict mode': typescriptBetterer('./tsconfig.json', {
+  'typescript use strict mode': typescript('./tsconfig.json', {
     strict: true
   })
 };    

--- a/test/betterer-skip.spec.ts
+++ b/test/betterer-skip.spec.ts
@@ -7,7 +7,7 @@ describe('betterer', () => {
     const { logs, paths, readFile, cleanup, resolve, writeFile } = await createFixture('test-betterer-skip', {
       '.betterer.skip.ts': `
 import { bigger } from '@betterer/constraints';
-import { regexpBetterer } from '@betterer/regexp';
+import { regexp } from '@betterer/regexp';
 
 let start = 0;
 
@@ -17,12 +17,12 @@ export default {
     constraint: bigger,
     isSkipped: true
   },
-  'test 2': regexpBetterer('./src/**/*.ts', /(\\/\\/\\s*HACK)/i).skip()
+  'test 2': regexp(/(\\/\\/\\s*HACK)/i).include('./src/**/*.ts').skip()
 };
       `,
       '.betterer.ts': `
 import { bigger } from '@betterer/constraints';
-import { regexpBetterer } from '@betterer/regexp';
+import { regexp } from '@betterer/regexp';
 
 let start = 0;
 
@@ -31,7 +31,7 @@ export default {
     test: () => start++,
     constraint: bigger
   },
-  'test 2': regexpBetterer('./src/**/*.ts', /(\\/\\/\\s*HACK)/i)
+  'test 2': regexp(/(\\/\\/\\s*HACK)/i).include('./src/**/*.ts')
 };
       `
     });

--- a/test/betterer-tsquery.spec.ts
+++ b/test/betterer-tsquery.spec.ts
@@ -6,28 +6,28 @@ describe('betterer', () => {
   it('should report the existence of TSQuery matches', async () => {
     const { logs, paths, readFile, cleanup, resolve, writeFile } = await createFixture('test-betterer-tsquery', {
       '.betterer.ts': `
-import { tsqueryBetterer } from '@betterer/tsquery';
+import { tsquery } from '@betterer/tsquery';
 
 export default {
-  'tsquery no raw console.log': tsqueryBetterer(
-    './tsconfig.json',
-    'CallExpression > PropertyAccessExpression[expression.name="console"][name.name="log"]'
-  )
+'tsquery no raw console.log': tsquery(
+  './tsconfig.json',
+  'CallExpression > PropertyAccessExpression[expression.name="console"][name.name="log"]'
+)
 };      
-      `,
+    `,
       'tsconfig.json': `
 {
-  "compilerOptions": {
-    "noEmit": true,
-    "lib": ["esnext"],
-    "moduleResolution": "node",
-    "target": "ES5",
-    "typeRoots": ["../../node_modules/@types/"],
-    "resolveJsonModule": true
-  },
-  "include": ["./src/**/*", ".betterer.ts"]
+"compilerOptions": {
+  "noEmit": true,
+  "lib": ["esnext"],
+  "moduleResolution": "node",
+  "target": "ES5",
+  "typeRoots": ["../../node_modules/@types/"],
+  "resolveJsonModule": true
+},
+"include": ["./src/**/*", ".betterer.ts"]
 }      
-      `
+    `
     });
 
     const configPaths = [paths.config];
@@ -72,12 +72,12 @@ export default {
   it('should throw if there is no configFilePath', async () => {
     const { paths, logs, cleanup } = await createFixture('test-betterer-tsquery-no-config-file-path', {
       '.betterer.js': `
-const { tsqueryBetterer } = require('@betterer/tsquery');
+const { tsquery } = require('@betterer/tsquery');
 
 module.exports = {
-  'tsquery no raw console.log': tsqueryBetterer()
+'tsquery no raw console.log': tsquery()
 };      
-      `
+    `
     });
 
     const configPaths = [paths.config];
@@ -93,12 +93,12 @@ module.exports = {
   it('should throw if there is no query', async () => {
     const { paths, logs, cleanup } = await createFixture('test-betterer-tsquery-no-query', {
       '.betterer.js': `
-const { tsqueryBetterer } = require('@betterer/tsquery');
+const { tsquery } = require('@betterer/tsquery');
 
 module.exports = {
-  'tsquery no raw console.log': tsqueryBetterer('./tsconfig.json')
+'tsquery no raw console.log': tsquery('./tsconfig.json')
 };
-      `
+    `
     });
 
     const configPaths = [paths.config];
@@ -109,5 +109,118 @@ module.exports = {
     expect(logs).toMatchSnapshot();
 
     await cleanup();
+  });
+
+  describe('tsqueryBetterer (deprecated)', () => {
+    it('should report the existence of TSQuery matches', async () => {
+      const { logs, paths, readFile, cleanup, resolve, writeFile } = await createFixture(
+        'test-betterer-tsquery-deprecated',
+        {
+          '.betterer.ts': `
+import { tsqueryBetterer } from '@betterer/tsquery';
+
+export default {
+  'tsquery no raw console.log': tsqueryBetterer(
+    './tsconfig.json',
+    'CallExpression > PropertyAccessExpression[expression.name="console"][name.name="log"]'
+  )
+};      
+      `,
+          'tsconfig.json': `
+{
+  "compilerOptions": {
+    "noEmit": true,
+    "lib": ["esnext"],
+    "moduleResolution": "node",
+    "target": "ES5",
+    "typeRoots": ["../../node_modules/@types/"],
+    "resolveJsonModule": true
+  },
+  "include": ["./src/**/*", ".betterer.ts"]
+}      
+      `
+        }
+      );
+
+      const configPaths = [paths.config];
+      const resultsPath = paths.results;
+      const indexPath = resolve('./src/index.ts');
+
+      await writeFile(indexPath, `console.log('foo');`);
+
+      const newTestRun = await betterer({ configPaths, resultsPath });
+
+      expect(newTestRun.new).toEqual(['tsquery no raw console.log']);
+
+      const sameTestRun = await betterer({ configPaths, resultsPath });
+
+      expect(sameTestRun.same).toEqual(['tsquery no raw console.log']);
+
+      await writeFile(indexPath, `console.log('foo');\nconsole.log('foo');`);
+
+      const worseTestRun = await betterer({ configPaths, resultsPath });
+
+      expect(worseTestRun.worse).toEqual(['tsquery no raw console.log']);
+
+      const result = await readFile(resultsPath);
+
+      expect(result).toMatchSnapshot();
+
+      await writeFile(indexPath, ``);
+
+      const betterTestRun = await betterer({ configPaths, resultsPath });
+
+      expect(betterTestRun.better).toEqual(['tsquery no raw console.log']);
+
+      const completedTestRun = await betterer({ configPaths, resultsPath });
+
+      expect(completedTestRun.completed).toEqual(['tsquery no raw console.log']);
+
+      expect(logs).toMatchSnapshot();
+
+      await cleanup();
+    });
+
+    it('should throw if there is no configFilePath', async () => {
+      const { paths, logs, cleanup } = await createFixture('test-betterer-tsquery-no-config-file-path-deprecated', {
+        '.betterer.js': `
+const { tsqueryBetterer } = require('@betterer/tsquery');
+
+module.exports = {
+  'tsquery no raw console.log': tsqueryBetterer()
+};      
+      `
+      });
+
+      const configPaths = [paths.config];
+      const resultsPath = paths.results;
+
+      await expect(async () => await betterer({ configPaths, resultsPath })).rejects.toThrow();
+
+      expect(logs).toMatchSnapshot();
+
+      await cleanup();
+    });
+
+    it('should throw if there is no query', async () => {
+      const { paths, logs, cleanup } = await createFixture('test-betterer-tsquery-no-query-deprecated', {
+        '.betterer.js': `
+const { tsqueryBetterer } = require('@betterer/tsquery');
+
+module.exports = {
+  'tsquery no raw console.log': tsqueryBetterer('./tsconfig.json')
+};
+      `
+      });
+
+      const configPaths = [paths.config];
+      const resultsPath = paths.results;
+
+      await expect(async () => await betterer({ configPaths, resultsPath })).rejects.toThrow();
+
+      expect(logs).toMatchSnapshot();
+
+      await cleanup();
+    });
   });
 });

--- a/test/betterer-typescript-strict.spec.ts
+++ b/test/betterer-typescript-strict.spec.ts
@@ -40,10 +40,10 @@ describe('betterer', () => {
       'test-betterer-typescript-strict',
       {
         '.betterer.ts': `
-import { typescriptBetterer } from '@betterer/typescript';
+import { typescript } from '@betterer/typescript';
 
 export default {
-  'typescript use strict mode': typescriptBetterer('./tsconfig.json', {
+  'typescript use strict mode': typescript('./tsconfig.json', {
     strict: true
   })
 };

--- a/test/betterer-typescript.spec.ts
+++ b/test/betterer-typescript.spec.ts
@@ -5,10 +5,10 @@ describe('betterer', () => {
   it('should report the status of the TypeScript compiler', async () => {
     const { paths, logs, resolve, readFile, cleanup, writeFile } = await createFixture('test-betterer-typescript', {
       '.betterer.ts': `
-import { typescriptBetterer } from '@betterer/typescript';
+import { typescript } from '@betterer/typescript';
 
 export default {
-  'typescript use strict mode': typescriptBetterer('./tsconfig.json', {
+  'typescript use strict mode': typescript('./tsconfig.json', {
     strict: true
   })
 };
@@ -70,10 +70,10 @@ export default {
   it('should throw if there is no configFilePath', async () => {
     const { paths, logs, cleanup } = await createFixture('test-betterer-typescript-no-config-file-path', {
       '.betterer.js': `
-const { typescriptBetterer } = require('@betterer/typescript');
+const { typescript } = require('@betterer/typescript');
 
 module.exports = {
-  'typescript use strict mode': typescriptBetterer()
+  'typescript use strict mode': typescript()
 };
       `
     });
@@ -91,10 +91,10 @@ module.exports = {
   it('should throw if there is no extraCompilerOptions', async () => {
     const { paths, logs, cleanup } = await createFixture('test-betterer-typescript-no-compiler-options', {
       '.betterer.js': `
-const { typescriptBetterer } = require('@betterer/typescript');
+const { typescript } = require('@betterer/typescript');
 
 module.exports = {
-  'typescript use strict mode': typescriptBetterer('./tsconfig.json')
+  'typescript use strict mode': typescript('./tsconfig.json')
 };
       `
     });
@@ -107,5 +107,117 @@ module.exports = {
     expect(logs).toMatchSnapshot();
 
     await cleanup();
+  });
+
+  describe('typescriptBetterer (deprecated)', () => {
+    it('should report the status of the TypeScript compiler', async () => {
+      const { paths, logs, resolve, readFile, cleanup, writeFile } = await createFixture(
+        'test-betterer-typescript-deprecated',
+        {
+          '.betterer.ts': `
+import { typescriptBetterer } from '@betterer/typescript';
+
+export default {
+  'typescript use strict mode': typescriptBetterer('./tsconfig.json', {
+    strict: true
+  })
+};
+      `,
+          'tsconfig.json': `
+{
+  "compilerOptions": {
+    "noEmit": true,
+    "lib": ["esnext"],
+    "moduleResolution": "node",
+    "target": "ES5",
+    "typeRoots": ["../../node_modules/@types/"],
+    "resolveJsonModule": true
+  },
+  "include": ["./src/**/*", ".betterer.ts"]
+}
+      `
+        }
+      );
+
+      const configPaths = [paths.config];
+      const resultsPath = paths.results;
+      const indexPath = resolve('./src/index.ts');
+
+      await writeFile(indexPath, `const a = 'a';\nconst one = 1;\nconsole.log(a * one);`);
+
+      const newTestRun = await betterer({ configPaths, resultsPath });
+
+      expect(newTestRun.new).toEqual(['typescript use strict mode']);
+
+      const sameTestRun = await betterer({ configPaths, resultsPath });
+
+      expect(sameTestRun.same).toEqual(['typescript use strict mode']);
+
+      await writeFile(indexPath, `const a = 'a';\nconst one = 1;\nconsole.log(a * one, one * a);`);
+
+      const worseTestRun = await betterer({ configPaths, resultsPath });
+
+      expect(worseTestRun.worse).toEqual(['typescript use strict mode']);
+
+      const result = await readFile(resultsPath);
+
+      expect(result).toMatchSnapshot();
+
+      await writeFile(indexPath, ``);
+
+      const betterTestRun = await betterer({ configPaths, resultsPath });
+
+      expect(betterTestRun.better).toEqual(['typescript use strict mode']);
+
+      const completedTestRun = await betterer({ configPaths, resultsPath });
+
+      expect(completedTestRun.completed).toEqual(['typescript use strict mode']);
+
+      expect(logs).toMatchSnapshot();
+
+      await cleanup();
+    });
+
+    it('should throw if there is no configFilePath', async () => {
+      const { paths, logs, cleanup } = await createFixture('test-betterer-typescript-no-config-file-path-deprecated', {
+        '.betterer.js': `
+const { typescriptBetterer } = require('@betterer/typescript');
+
+module.exports = {
+  'typescript use strict mode': typescriptBetterer()
+};
+      `
+      });
+
+      const configPaths = [paths.config];
+      const resultsPath = paths.results;
+
+      await expect(async () => await betterer({ configPaths, resultsPath })).rejects.toThrow();
+
+      expect(logs).toMatchSnapshot();
+
+      await cleanup();
+    });
+
+    it('should throw if there is no extraCompilerOptions', async () => {
+      const { paths, logs, cleanup } = await createFixture('test-betterer-typescript-no-compiler-options-deprecated', {
+        '.betterer.js': `
+const { typescriptBetterer } = require('@betterer/typescript');
+
+module.exports = {
+  'typescript use strict mode': typescriptBetterer('./tsconfig.json')
+};
+      `
+      });
+
+      const configPaths = [paths.config];
+      const resultsPath = paths.results;
+
+      await expect(async () => await betterer({ configPaths, resultsPath })).rejects.toThrow();
+
+      expect(logs).toMatchSnapshot();
+
+      await cleanup();
+    });
   });
 });

--- a/test/betterer-worse.spec.ts
+++ b/test/betterer-worse.spec.ts
@@ -46,10 +46,10 @@ module.exports = {
   it('should not stay worse if an update is forced', async () => {
     const { logs, paths, readFile, cleanup, resolve, writeFile } = await createFixture('test-betterer-update', {
       '.betterer.ts': `
-import { tsqueryBetterer } from '@betterer/tsquery';
+import { tsquery } from '@betterer/tsquery';
 
 export default {
-  'tsquery no raw console.log': tsqueryBetterer(
+  'tsquery no raw console.log': tsquery(
     './tsconfig.json',
     'CallExpression > PropertyAccessExpression[expression.name="console"][name.name="log"]'
   )

--- a/test/single/betterer-single.spec.ts
+++ b/test/single/betterer-single.spec.ts
@@ -6,10 +6,10 @@ describe('betterer.single', () => {
   it('should run eslint against a single file', async () => {
     const { paths, resolve, cleanup, writeFile } = await createFixture('test-betterer-eslint-single', {
       '.betterer.js': `
-const { eslintBetterer } = require('@betterer/eslint');
+const { eslint } = require('@betterer/eslint');
 
 module.exports = {
-  'eslint enable new rule': eslintBetterer('./src/**/*.ts', ['no-debugger', 'error'])
+  'eslint enable new rule': eslint({ 'no-debugger': 'error' }).include('./src/**/*.ts')
 };    
       `,
       '.eslintrc.js': `
@@ -60,10 +60,10 @@ module.exports = {
   it('should ignore any files outside of the scope of the eslint test glob', async () => {
     const { paths, resolve, cleanup, writeFile } = await createFixture('test-betterer-eslint-single-irrelevant', {
       '.betterer.js': `
-const { eslintBetterer } = require('@betterer/eslint');
+const { eslint } = require('@betterer/eslint');
 
 module.exports = {
-  'eslint enable new rule': eslintBetterer('./src/**/*.ts', ['no-debugger', 'error'])
+  'eslint enable new rule': eslint({ 'no-debugger': 'error'}).include('./src/**/*.ts')
 };    
       `,
       '.eslintrc.js': `
@@ -114,10 +114,10 @@ module.exports = {
   it('should run regexp against a single file', async () => {
     const { paths, resolve, cleanup, writeFile } = await createFixture('test-betterer-regexp-single', {
       '.betterer.js': `
-const { regexpBetterer } = require('@betterer/regexp');
+const { regexp } = require('@betterer/regexp');
 
 module.exports = {
-  'regexp no hack comments': regexpBetterer('./src/**/*.ts', /(\\/\\/\\s*HACK)/i)
+  'regexp no hack comments': regexp(/(\\/\\/\\s*HACK)/i).include('./src/**/*.ts')
 };
       `
     });
@@ -140,10 +140,10 @@ module.exports = {
   it('should ignore any files outside of the scope of the regexp test glob', async () => {
     const { paths, resolve, cleanup, writeFile } = await createFixture('test-betterer-regexp-single-irrelevant', {
       '.betterer.js': `
-const { regexpBetterer } = require('@betterer/regexp');
+const { regexp } = require('@betterer/regexp');
 
 module.exports = {
-  'regexp no hack comments': regexpBetterer('./src/**/*.ts', /(\\/\\/\\s*HACK)/i)
+  'regexp no hack comments': regexp(/(\\/\\/\\s*HACK)/i).include('./src/**/*.ts')
 };
       `
     });
@@ -166,10 +166,10 @@ module.exports = {
   it('should run tsquery against a single file', async () => {
     const { paths, resolve, cleanup, writeFile } = await createFixture('test-betterer-tsquery-single', {
       '.betterer.ts': `
-import { tsqueryBetterer } from '@betterer/tsquery';
+import { tsquery } from '@betterer/tsquery';
 
 export default {
-  'tsquery no raw console.log': tsqueryBetterer(
+  'tsquery no raw console.log': tsquery(
     './tsconfig.json',
     'CallExpression > PropertyAccessExpression[expression.name="console"][name.name="log"]'
   )
@@ -208,10 +208,10 @@ export default {
   it('should ignore any files outside of the scope of the tsquery tsconfig', async () => {
     const { paths, resolve, cleanup, writeFile } = await createFixture('test-betterer-tsquery-single-irrevelent', {
       '.betterer.ts': `
-import { tsqueryBetterer } from '@betterer/tsquery';
+import { tsquery } from '@betterer/tsquery';
 
 export default {
-  'tsquery no raw console.log': tsqueryBetterer(
+  'tsquery no raw console.log': tsquery(
     './tsconfig.json',
     'CallExpression > PropertyAccessExpression[expression.name="console"][name.name="log"]'
   )
@@ -250,10 +250,10 @@ export default {
   it('should run typescript against a single file', async () => {
     const { paths, resolve, cleanup, writeFile } = await createFixture('test-betterer-typescript-single', {
       '.betterer.ts': `
-import { typescriptBetterer } from '@betterer/typescript';
+import { typescript } from '@betterer/typescript';
 
 export default {
-  'typescript use strict mode': typescriptBetterer('./tsconfig.json', {
+  'typescript use strict mode': typescript('./tsconfig.json', {
     strict: true
   })
 };
@@ -291,10 +291,10 @@ export default {
   it('should ignore any files outside of the scope of the typescript tsconfig', async () => {
     const { paths, resolve, cleanup, writeFile } = await createFixture('test-betterer-typescript-single-irrelevent', {
       '.betterer.ts': `
-import { typescriptBetterer } from '@betterer/typescript';
+import { typescript } from '@betterer/typescript';
 
 export default {
-  'typescript use strict mode': typescriptBetterer('./tsconfig.json', {
+  'typescript use strict mode': typescript('./tsconfig.json', {
     strict: true
   })
 };

--- a/test/watch/betterer-watch.spec.ts
+++ b/test/watch/betterer-watch.spec.ts
@@ -6,10 +6,10 @@ describe('betterer.watch', () => {
   it('should run in watch mode', async () => {
     const { logs, paths, resolve, cleanup, writeFile, waitForRun } = await createFixture('test-betterer-watch', {
       '.betterer.ts': `
-import { tsqueryBetterer } from '@betterer/tsquery';
+import { tsquery } from '@betterer/tsquery';
 
 export default {
-  'tsquery no raw console.log': tsqueryBetterer(
+  'tsquery no raw console.log': tsquery(
     './tsconfig.json',
     'CallExpression > PropertyAccessExpression[expression.name="console"][name.name="log"]'
   )
@@ -71,10 +71,10 @@ export default {
       'test-betterer-watch-debounce',
       {
         '.betterer.ts': `
-import { tsqueryBetterer } from '@betterer/tsquery';
+import { tsquery } from '@betterer/tsquery';
 
 export default {
-  'tsquery no raw console.log': tsqueryBetterer(
+  'tsquery no raw console.log': tsquery(
     './tsconfig.json',
     'CallExpression > PropertyAccessExpression[expression.name="console"][name.name="log"]'
   )
@@ -122,10 +122,10 @@ export default {
       'test-betterer-watch-debounce',
       {
         '.betterer.ts': `
-import { tsqueryBetterer } from '@betterer/tsquery';
+import { tsquery } from '@betterer/tsquery';
 
 export default {
-  'tsquery no raw console.log': tsqueryBetterer(
+  'tsquery no raw console.log': tsquery(
     './tsconfig.json',
     'CallExpression > PropertyAccessExpression[expression.name="console"][name.name="log"]'
   )


### PR DESCRIPTION
* Deprecate `eslintBetterer`, `regexpBetterer`, `tsqueryBetterer` and `typescriptBetterer`
* Add `eslint`, `regexp`, `tsquery` and `typescript`.
* Users should use `include()` over custom parameters.