### PR TITLE
feat(betterer ✨): removing timestamps

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -1,6 +1,5 @@
-// BETTERER RESULTS V1.
+// BETTERER RESULTS V2.
 exports[`no hack comments`] = {
-  timestamp: 1589338467072,
   value: `{
     "packages/cli/src/cli.ts:2439790794": [
       [12, 0, 7, "RegExp match", "645651780"]
@@ -12,7 +11,6 @@ exports[`no hack comments`] = {
 };
 
 exports[`new eslint rules`] = {
-  timestamp: 1593526033477,
   value: `{
     "packages/betterer/src/config/config.ts:2688898251": [
       [35, 2, 72, "Unsafe return of an any[] typed value", "2233173152"]
@@ -121,7 +119,7 @@ exports[`new eslint rules`] = {
       [63, 4, 71, "Promises must be handled appropriately or explicitly marked as ignored with the \`void\` operator.", "2936064845"],
       [69, 6, 27, "Promises must be handled appropriately or explicitly marked as ignored with the \`void\` operator.", "3607138074"]
     ],
-    "packages/extension/src/server/validator.ts:3258157153": [
+    "packages/extension/src/server/validator.ts:2916623605": [
       [48, 10, 90, "Promises must be handled appropriately or explicitly marked as ignored with the \`void\` operator.", "1821734533"],
       [95, 12, 94, "Promises must be handled appropriately or explicitly marked as ignored with the \`void\` operator.", "2449957056"]
     ],

--- a/README.md
+++ b/README.md
@@ -63,8 +63,8 @@ betterer
 **`Betterer`** will run your test the first time, and store a snapshot of the result in a new file called `.betterer.results`.
 
 ```js
-// BETTERER RESULTS V1.
-exports[`thing to improve`] = { timestamp: 1569148039311, value: `5` };
+// BETTERER RESULTS V2.
+exports[`thing to improve`] = { value: `5` };
 ```
 
 The next step is to add **`Betterer`** to your build pipeline. Whenever your code builds, **`Betterer`** will run the test again and make sure the result hasn't got worse. If it gets better, then the `.betterer.results` file will be updated with the new value, which you can then commit to your codebase!

--- a/packages/betterer/src/context/run.ts
+++ b/packages/betterer/src/context/run.ts
@@ -41,7 +41,6 @@ export class BettererRun {
     } else {
       this._isNew = false;
       this._expected = deserialise(this, expected.value);
-      this._timestamp = expected.timestamp;
       this._toPrint = this._expected;
       this._hasResult = true;
     }
@@ -121,13 +120,12 @@ export class BettererRun {
     return this._test;
   }
 
-  public better(result: unknown, isComplete: boolean, timestamp: number): void {
+  public better(result: unknown, isComplete: boolean): void {
     assert.equal(this._status, BettererRunStatus.pending);
     this._status = BettererRunStatus.better;
     this._isComplete = isComplete;
     this._result = result;
     this._toPrint = result;
-    this._timestamp = timestamp;
     this._hasResult = true;
     this._context.runBetter(this);
   }
@@ -142,13 +140,12 @@ export class BettererRun {
     this._context.runFailed(this);
   }
 
-  public neww(result: unknown, isComplete: boolean, timestamp: number): void {
+  public neww(result: unknown, isComplete: boolean): void {
     assert.equal(this._status, BettererRunStatus.pending);
     this._status = BettererRunStatus.neww;
     this._isComplete = isComplete;
     this._result = result;
     this._toPrint = result;
-    this._timestamp = timestamp;
     this._hasResult = true;
     this._context.runNew(this);
   }
@@ -157,11 +154,11 @@ export class BettererRun {
     this._context.runRan(this);
   }
 
-  public start(): number {
+  public start(): void {
     const startTime = Date.now();
     this._isExpired = startTime > this._test.deadline;
     this._context.runStart(this);
-    return startTime;
+    this._timestamp = startTime;
   }
 
   public same(result: unknown): void {

--- a/packages/betterer/src/results/printer.ts
+++ b/packages/betterer/src/results/printer.ts
@@ -8,11 +8,11 @@ import { serialise } from './serialiser';
 const UNESCAPED = '"\n';
 
 export async function print(run: BettererRun): Promise<string> {
-  const { name, test, timestamp } = run;
+  const { name, test } = run;
   const printer = test.printer || defaultPrinter;
   const printedValue = await printer(run, serialise(run));
   const escaped = escape(printedValue, UNESCAPED);
-  return `\nexports[\`${name}\`] = {\n  timestamp: ${timestamp},\n  value: \`${escaped}\`\n};\n`;
+  return `\nexports[\`${name}\`] = {\n  value: \`${escaped}\`\n};\n`;
 }
 
 function defaultPrinter(_: BettererRun, value: unknown): string {

--- a/packages/betterer/src/results/types.ts
+++ b/packages/betterer/src/results/types.ts
@@ -1,12 +1,6 @@
 export const NO_PREVIOUS_RESULT = Symbol('No Previous Result');
 
-export type BettererResult = {
-  timestamp: number;
-  value: unknown;
-};
-export type BettererResults = Record<string, BettererResult>;
 export type BettererExpectedResult = {
-  timestamp: number;
   value: string;
 };
 export type BettererExpectedResults = Record<string, BettererExpectedResult>;

--- a/packages/betterer/src/results/writer.ts
+++ b/packages/betterer/src/results/writer.ts
@@ -2,7 +2,7 @@ import { promises as fs } from 'fs';
 
 import { COULDNT_WRITE_RESULTS } from '../errors';
 
-const RESULTS_HEADER = `// BETTERER RESULTS V1.`;
+const RESULTS_HEADER = `// BETTERER RESULTS V2.`;
 
 export async function write(printed: Array<string>, resultsPath: string): Promise<void> {
   const toWrite = [RESULTS_HEADER, ...printed].join('');

--- a/packages/betterer/src/runner/runner.ts
+++ b/packages/betterer/src/runner/runner.ts
@@ -35,7 +35,7 @@ async function runTest(run: BettererRun): Promise<void> {
     return;
   }
 
-  const timestamp = run.start();
+  run.start();
   let result: unknown;
   try {
     result = await test.test(run);
@@ -49,7 +49,7 @@ async function runTest(run: BettererRun): Promise<void> {
   const goalComplete = await test.goal(result);
 
   if (run.isNew) {
-    run.neww(result, goalComplete, timestamp);
+    run.neww(result, goalComplete);
     return;
   }
 
@@ -61,7 +61,7 @@ async function runTest(run: BettererRun): Promise<void> {
   }
 
   if (comparison === ConstraintResult.better) {
-    run.better(result, goalComplete, timestamp);
+    run.better(result, goalComplete);
     return;
   }
 

--- a/packages/extension/src/server/validator.ts
+++ b/packages/extension/src/server/validator.ts
@@ -84,10 +84,10 @@ export class BettererValidator {
                 existingIssues = file.issuesRaw;
               }
               existingIssues.forEach((issue: BettererFileIssueRaw | BettererFileIssueDeserialised) => {
-                diagnostics.push(createWarning(test.name, run.timestamp, issue, document));
+                diagnostics.push(createWarning(test.name, 'existing issue', issue, document));
               });
               newIssues.forEach((issue) => {
-                diagnostics.push(createError(test.name, issue, document));
+                diagnostics.push(createError(test.name, 'new issue', issue, document));
               });
             });
           this._connection.sendDiagnostics({ uri, diagnostics });
@@ -113,7 +113,7 @@ function isRaw(issue: BettererFileIssueRaw | BettererFileIssueDeserialised): iss
 function createDiagnostic(
   name: string,
   issue: BettererFileIssueRaw | BettererFileIssueDeserialised,
-  code: string,
+  extra: string,
   document: TextDocument,
   severity: DiagnosticSeverity
 ): Diagnostic {
@@ -129,33 +129,32 @@ function createDiagnostic(
     end = document.positionAt(document.offsetAt(start) + length);
   }
   const range = { start, end };
+  const code = `[${name}]${extra ? ` - ${extra}` : ''}`;
   return {
     message,
     severity,
     source: EXTENSION_NAME,
     range,
-    code: `[${name}] - ${code}`
+    code
   };
 }
 
 function createError(
   name: string,
+  extra: string,
   issue: BettererFileIssueRaw | BettererFileIssueDeserialised,
   document: TextDocument
 ): Diagnostic {
-  const code = 'new issue';
-  return createDiagnostic(name, issue, code, document, DiagnosticSeverity.Error);
+  return createDiagnostic(name, issue, extra, document, DiagnosticSeverity.Error);
 }
 
 function createWarning(
   name: string,
-  timestamp: number,
+  extra: string,
   issue: BettererFileIssueRaw | BettererFileIssueDeserialised,
   document: TextDocument
 ): Diagnostic {
-  const date = new Date(timestamp).toISOString().replace(/T/, ' ').replace(/\..+/, '');
-  const code = `since ${date}`;
-  return createDiagnostic(name, issue, code, document, DiagnosticSeverity.Warning);
+  return createDiagnostic(name, issue, extra, document, DiagnosticSeverity.Warning);
 }
 
 function getFilePath(documentOrUri: URI | TextDocument | string): string | null {

--- a/test/__snapshots__/betterer-better.spec.ts.snap
+++ b/test/__snapshots__/betterer-better.spec.ts.snap
@@ -36,9 +36,8 @@ Array [
 `;
 
 exports[`betterer should work when a test changes and makes the results better 2`] = `
-"// BETTERER RESULTS V1.
+"// BETTERER RESULTS V2.
 exports[\`no raw console calls\`] = {
-  timestamp: 0,
   value: \`{
     \\"src/index.ts:913095150\\": [
       [0, 0, 11, \\"TSQuery match\\", \\"3870399096\\"],
@@ -93,14 +92,12 @@ Array [
 `;
 
 exports[`betterer should work when a test gets better 2`] = `
-"// BETTERER RESULTS V1.
+"// BETTERER RESULTS V2.
 exports[\`should shrink\`] = {
-  timestamp: 0,
   value: \`1\`
 };
 
 exports[\`should grow\`] = {
-  timestamp: 0,
   value: \`1\`
 };
 "

--- a/test/__snapshots__/betterer-complete.spec.ts.snap
+++ b/test/__snapshots__/betterer-complete.spec.ts.snap
@@ -74,4 +74,4 @@ Array [
 ]
 `;
 
-exports[`betterer should work when a test meets its goal 2`] = `"// BETTERER RESULTS V1."`;
+exports[`betterer should work when a test meets its goal 2`] = `"// BETTERER RESULTS V2."`;

--- a/test/__snapshots__/betterer-config-ts-esm.spec.ts.snap
+++ b/test/__snapshots__/betterer-config-ts-esm.spec.ts.snap
@@ -44,9 +44,8 @@ Array [
 `;
 
 exports[`betterer should work with a .betterer.ts file that uses ES modules 2`] = `
-"// BETTERER RESULTS V1.
+"// BETTERER RESULTS V2.
 exports[\`gets better\`] = {
-  timestamp: 0,
   value: \`1\`
 };
 "

--- a/test/__snapshots__/betterer-config-ts.spec.ts.snap
+++ b/test/__snapshots__/betterer-config-ts.spec.ts.snap
@@ -36,9 +36,8 @@ Array [
 `;
 
 exports[`betterer should work with a .betterer.ts file 2`] = `
-"// BETTERER RESULTS V1.
+"// BETTERER RESULTS V2.
 exports[\`gets better\`] = {
-  timestamp: 0,
   value: \`1\`
 };
 "

--- a/test/__snapshots__/betterer-conflict.spec.ts.snap
+++ b/test/__snapshots__/betterer-conflict.spec.ts.snap
@@ -21,9 +21,8 @@ Array [
 `;
 
 exports[`betterer should work when there is a merge conflict in the results file 2`] = `
-"// BETTERER RESULTS V1.
+"// BETTERER RESULTS V2.
 exports[\`no raw console calls\`] = {
-  timestamp: 0,
   value: \`{
     \\"src/index.ts:1884655653\\": [
       [0, 0, 11, \\"TSQuery match\\", \\"3870399096\\"]

--- a/test/__snapshots__/betterer-deadline.spec.ts.snap
+++ b/test/__snapshots__/betterer-deadline.spec.ts.snap
@@ -21,9 +21,8 @@ Array [
 `;
 
 exports[`betterer should do nothing when a test is not past its deadline 2`] = `
-"// BETTERER RESULTS V1.
+"// BETTERER RESULTS V2.
 exports[\`should grow\`] = {
-  timestamp: 1589714460851,
   value: \`0\`
 };
 "
@@ -54,9 +53,8 @@ Array [
 `;
 
 exports[`betterer should mark a test as expired when is is past its deadline 2`] = `
-"// BETTERER RESULTS V1.
+"// BETTERER RESULTS V2.
 exports[\`should grow\`] = {
-  timestamp: 1589714460851,
   value: \`0\`
 };
 "

--- a/test/__snapshots__/betterer-eslint-complex.spec.ts.snap
+++ b/test/__snapshots__/betterer-eslint-complex.spec.ts.snap
@@ -1,9 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`betterer should report the status of a new eslint rule with a complex set up 1`] = `
-"// BETTERER RESULTS V1.
+"// BETTERER RESULTS V2.
 exports[\`eslint enable no-debugger rule\`] = {
-  timestamp: 0,
   value: \`{
     \\"src/index.ts:3201740415\\": [
       [0, 0, 9, \\"Unexpected \\\\'debugger\\\\' statement.\\", \\"3201740415\\"]

--- a/test/__snapshots__/betterer-eslint-options.spec.ts.snap
+++ b/test/__snapshots__/betterer-eslint-options.spec.ts.snap
@@ -1,9 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`betterer should handlex complex eslint rule options 1`] = `
-"// BETTERER RESULTS V1.
+"// BETTERER RESULTS V2.
 exports[\`eslint enable complex rule\`] = {
-  timestamp: 0,
   value: \`{
     \\"src/index.ts:1015454386\\": [
       [0, 0, 34, \\"Prefer named exports\\", \\"1332276585\\"]

--- a/test/__snapshots__/betterer-eslint.spec.ts.snap
+++ b/test/__snapshots__/betterer-eslint.spec.ts.snap
@@ -1,9 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`betterer eslintBetterer (deprecated) should report the status of a new eslint rule 1`] = `
-"// BETTERER RESULTS V1.
+"// BETTERER RESULTS V2.
 exports[\`eslint enable new rule\`] = {
-  timestamp: 0,
   value: \`{
     \\"src/index.ts:3201740415\\": [
       [0, 0, 9, \\"Unexpected \\\\'debugger\\\\' statement.\\", \\"3201740415\\"]
@@ -145,9 +144,8 @@ Array [
 `;
 
 exports[`betterer should report the status of a new eslint rule 1`] = `
-"// BETTERER RESULTS V1.
+"// BETTERER RESULTS V2.
 exports[\`eslint enable new rule\`] = {
-  timestamp: 0,
   value: \`{
     \\"src/index.ts:3201740415\\": [
       [0, 0, 9, \\"Unexpected \\\\'debugger\\\\' statement.\\", \\"3201740415\\"]

--- a/test/__snapshots__/betterer-exclude.spec.ts.snap
+++ b/test/__snapshots__/betterer-exclude.spec.ts.snap
@@ -1,9 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`betterer should exclude specific files from results 1`] = `
-"// BETTERER RESULTS V1.
+"// BETTERER RESULTS V2.
 exports[\`regexp no hack comments\`] = {
-  timestamp: 0,
   value: \`{
     \\"src/exclude.ts:645618020\\": [
       [0, 0, 7, \\"RegExp match\\", \\"645618020\\"]
@@ -17,9 +16,8 @@ exports[\`regexp no hack comments\`] = {
 `;
 
 exports[`betterer should exclude specific files from results 2`] = `
-"// BETTERER RESULTS V1.
+"// BETTERER RESULTS V2.
 exports[\`regexp no hack comments\`] = {
-  timestamp: 0,
   value: \`{
     \\"src/index.ts:645618020\\": [
       [0, 0, 7, \\"RegExp match\\", \\"645618020\\"]

--- a/test/__snapshots__/betterer-failed.spec.ts.snap
+++ b/test/__snapshots__/betterer-failed.spec.ts.snap
@@ -17,7 +17,6 @@ Array [
   "could not write results to \\"<project>/fixtures/test-betterer-failed-writing/.betterer.results\\". 😔",
   "
 exports[\`should shrink\`] = {
-  timestamp: 0,
   value: \`0\`
 };
 ",
@@ -67,4 +66,4 @@ Array [
 ]
 `;
 
-exports[`betterer should work when a test fails 2`] = `"// BETTERER RESULTS V1."`;
+exports[`betterer should work when a test fails 2`] = `"// BETTERER RESULTS V2."`;

--- a/test/__snapshots__/betterer-named-exports.spec.ts.snap
+++ b/test/__snapshots__/betterer-named-exports.spec.ts.snap
@@ -36,9 +36,8 @@ Array [
 `;
 
 exports[`betterer should work with named exports in the config file 2`] = `
-"// BETTERER RESULTS V1.
+"// BETTERER RESULTS V2.
 exports[\`getsBetter\`] = {
-  timestamp: 0,
   value: \`1\`
 };
 "

--- a/test/__snapshots__/betterer-only.spec.ts.snap
+++ b/test/__snapshots__/betterer-only.spec.ts.snap
@@ -54,24 +54,20 @@ Array [
 `;
 
 exports[`betterer should run specific tests 2`] = `
-"// BETTERER RESULTS V1.
+"// BETTERER RESULTS V2.
 exports[\`test 1\`] = {
-  timestamp: 0,
   value: \`0\`
 };
 
 exports[\`test 2\`] = {
-  timestamp: 0,
   value: \`0\`
 };
 
 exports[\`test 3\`] = {
-  timestamp: 0,
   value: \`0\`
 };
 
 exports[\`test 4\`] = {
-  timestamp: 0,
   value: \`{
     \\"src/index.ts:4126639614\\": [
       [0, 0, 7, \\"RegExp match\\", \\"645651780\\"]

--- a/test/__snapshots__/betterer-regexp.spec.ts.snap
+++ b/test/__snapshots__/betterer-regexp.spec.ts.snap
@@ -1,9 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`betterer regexpBetterer (deprecated) should report the existence of RegExp matches 1`] = `
-"// BETTERER RESULTS V1.
+"// BETTERER RESULTS V2.
 exports[\`regexp no hack comments\`] = {
-  timestamp: 0,
   value: \`{
     \\"src/index.ts:4126639614\\": [
       [0, 0, 7, \\"RegExp match\\", \\"645651780\\"]
@@ -145,9 +144,8 @@ Array [
 `;
 
 exports[`betterer should report the existence of RegExp matches 1`] = `
-"// BETTERER RESULTS V1.
+"// BETTERER RESULTS V2.
 exports[\`regexp no hack comments\`] = {
-  timestamp: 0,
   value: \`{
     \\"src/index.ts:4126639614\\": [
       [0, 0, 7, \\"RegExp match\\", \\"645651780\\"]

--- a/test/__snapshots__/betterer-same.spec.ts.snap
+++ b/test/__snapshots__/betterer-same.spec.ts.snap
@@ -1,9 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`betterer should stay the same when a file is moved 1`] = `
-"// BETTERER RESULTS V1.
+"// BETTERER RESULTS V2.
 exports[\`typescript use strict mode\`] = {
-  timestamp: 0,
   value: \`{
     \\"src/index.ts:1499252024\\": [
       [2, 12, 1, \\"The left-hand side of an arithmetic operation must be of type \\\\'any\\\\', \\\\'number\\\\', \\\\'bigint\\\\' or an enum type.\\", \\"177604\\"]
@@ -14,9 +13,8 @@ exports[\`typescript use strict mode\`] = {
 `;
 
 exports[`betterer should stay the same when a file is moved 2`] = `
-"// BETTERER RESULTS V1.
+"// BETTERER RESULTS V2.
 exports[\`typescript use strict mode\`] = {
-  timestamp: 0,
   value: \`{
     \\"src/moved.ts:1499252024\\": [
       [2, 12, 1, \\"The left-hand side of an arithmetic operation must be of type \\\\'any\\\\', \\\\'number\\\\', \\\\'bigint\\\\' or an enum type.\\", \\"177604\\"]
@@ -62,9 +60,8 @@ Array [
 `;
 
 exports[`betterer should stay the same when an issue moves line 1`] = `
-"// BETTERER RESULTS V1.
+"// BETTERER RESULTS V2.
 exports[\`typescript use strict mode\`] = {
-  timestamp: 0,
   value: \`{
     \\"src/index.ts:1499252024\\": [
       [2, 12, 1, \\"The left-hand side of an arithmetic operation must be of type \\\\'any\\\\', \\\\'number\\\\', \\\\'bigint\\\\' or an enum type.\\", \\"177604\\"]
@@ -75,9 +72,8 @@ exports[\`typescript use strict mode\`] = {
 `;
 
 exports[`betterer should stay the same when an issue moves line 2`] = `
-"// BETTERER RESULTS V1.
+"// BETTERER RESULTS V2.
 exports[\`typescript use strict mode\`] = {
-  timestamp: 0,
   value: \`{
     \\"src/index.ts:2615232350\\": [
       [3, 12, 1, \\"The left-hand side of an arithmetic operation must be of type \\\\'any\\\\', \\\\'number\\\\', \\\\'bigint\\\\' or an enum type.\\", \\"177604\\"]
@@ -166,14 +162,12 @@ Array [
 `;
 
 exports[`betterer should work when a test is the same 2`] = `
-"// BETTERER RESULTS V1.
+"// BETTERER RESULTS V2.
 exports[\`doesn't get bigger\`] = {
-  timestamp: 0,
   value: \`0\`
 };
 
 exports[\`doesn't get smaller\`] = {
-  timestamp: 0,
   value: \`0\`
 };
 "

--- a/test/__snapshots__/betterer-skip.spec.ts.snap
+++ b/test/__snapshots__/betterer-skip.spec.ts.snap
@@ -36,14 +36,12 @@ Array [
 `;
 
 exports[`betterer should skip a test 2`] = `
-"// BETTERER RESULTS V1.
+"// BETTERER RESULTS V2.
 exports[\`test 1\`] = {
-  timestamp: 0,
   value: \`0\`
 };
 
 exports[\`test 2\`] = {
-  timestamp: 0,
   value: \`{
     \\"src/index.ts:4126639614\\": [
       [0, 0, 7, \\"RegExp match\\", \\"645651780\\"]

--- a/test/__snapshots__/betterer-tsquery.spec.ts.snap
+++ b/test/__snapshots__/betterer-tsquery.spec.ts.snap
@@ -1,9 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`betterer should report the existence of TSQuery matches 1`] = `
-"// BETTERER RESULTS V1.
+"// BETTERER RESULTS V2.
 exports[\`tsquery no raw console.log\`] = {
-  timestamp: 0,
   value: \`{
     \\"src/index.ts:4087252068\\": [
       [0, 0, 11, \\"TSQuery match\\", \\"3870399096\\"]
@@ -145,9 +144,8 @@ Array [
 `;
 
 exports[`betterer tsqueryBetterer (deprecated) should report the existence of TSQuery matches 1`] = `
-"// BETTERER RESULTS V1.
+"// BETTERER RESULTS V2.
 exports[\`tsquery no raw console.log\`] = {
-  timestamp: 0,
   value: \`{
     \\"src/index.ts:4087252068\\": [
       [0, 0, 11, \\"TSQuery match\\", \\"3870399096\\"]

--- a/test/__snapshots__/betterer-typescript-strict.spec.ts.snap
+++ b/test/__snapshots__/betterer-typescript-strict.spec.ts.snap
@@ -1,9 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`betterer should report the status of the TypeScript compiler in strict mode 1`] = `
-"// BETTERER RESULTS V1.
+"// BETTERER RESULTS V2.
 exports[\`typescript use strict mode\`] = {
-  timestamp: 0,
   value: \`{
     \\"src/index.ts:3281126131\\": [
       [0, 27, 4, \\"Parameter \\\\'list\\\\' implicitly has an \\\\'any\\\\' type.\\", \\"2087656743\\"],

--- a/test/__snapshots__/betterer-typescript.spec.ts.snap
+++ b/test/__snapshots__/betterer-typescript.spec.ts.snap
@@ -1,9 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`betterer should report the status of the TypeScript compiler 1`] = `
-"// BETTERER RESULTS V1.
+"// BETTERER RESULTS V2.
 exports[\`typescript use strict mode\`] = {
-  timestamp: 0,
   value: \`{
     \\"src/index.ts:1499252024\\": [
       [2, 12, 1, \\"The left-hand side of an arithmetic operation must be of type \\\\'any\\\\', \\\\'number\\\\', \\\\'bigint\\\\' or an enum type.\\", \\"177604\\"]
@@ -146,9 +145,8 @@ Array [
 `;
 
 exports[`betterer typescriptBetterer (deprecated) should report the status of the TypeScript compiler 1`] = `
-"// BETTERER RESULTS V1.
+"// BETTERER RESULTS V2.
 exports[\`typescript use strict mode\`] = {
-  timestamp: 0,
   value: \`{
     \\"src/index.ts:1499252024\\": [
       [2, 12, 1, \\"The left-hand side of an arithmetic operation must be of type \\\\'any\\\\', \\\\'number\\\\', \\\\'bigint\\\\' or an enum type.\\", \\"177604\\"]

--- a/test/__snapshots__/betterer-worse.spec.ts.snap
+++ b/test/__snapshots__/betterer-worse.spec.ts.snap
@@ -1,9 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`betterer should not stay worse if an update is forced 1`] = `
-"// BETTERER RESULTS V1.
+"// BETTERER RESULTS V2.
 exports[\`tsquery no raw console.log\`] = {
-  timestamp: 0,
   value: \`{
     \\"src/index.ts:315583663\\": [
       [0, 0, 11, \\"TSQuery match\\", \\"3870399096\\"],
@@ -137,14 +136,12 @@ Array [
 `;
 
 exports[`betterer should work when a test gets worse 2`] = `
-"// BETTERER RESULTS V1.
+"// BETTERER RESULTS V2.
 exports[\`should shrink\`] = {
-  timestamp: 0,
   value: \`0\`
 };
 
 exports[\`should grow\`] = {
-  timestamp: 0,
   value: \`2\`
 };
 "

--- a/test/betterer-conflict.spec.ts
+++ b/test/betterer-conflict.spec.ts
@@ -16,9 +16,8 @@ export default {
 };
               `,
       '.betterer.results': `
-// BETTERER RESULTS V1.
+// BETTERER RESULTS V2.
 exports[\`no raw console calls\`] = {
-  timestamp: 0,
   value: \`{
 |||<<<<<<< our-change
     \\"src/index.ts:315583663\\": [


### PR DESCRIPTION
Timestamps are causing weird merge issues in the the results file, and they don't provide much value.
Leaving most of the implementation in place so they can be used from reporters.
Bumping the version number in the header so it can be detected if needed.

BREAKING CHANGE: Remove timestamps from results file