### PR TITLE
fix(extension 🐛): cd to project dir before making checks

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -119,9 +119,9 @@ exports[`new eslint rules`] = {
       [63, 4, 71, "Promises must be handled appropriately or explicitly marked as ignored with the \`void\` operator.", "2936064845"],
       [69, 6, 27, "Promises must be handled appropriately or explicitly marked as ignored with the \`void\` operator.", "3607138074"]
     ],
-    "packages/extension/src/server/validator.ts:2916623605": [
+    "packages/extension/src/server/validator.ts:2557653799": [
       [48, 10, 90, "Promises must be handled appropriately or explicitly marked as ignored with the \`void\` operator.", "1821734533"],
-      [95, 12, 94, "Promises must be handled appropriately or explicitly marked as ignored with the \`void\` operator.", "2449957056"]
+      [96, 12, 94, "Promises must be handled appropriately or explicitly marked as ignored with the \`void\` operator.", "2449957056"]
     ],
     "packages/typescript/src/typescript.ts:405611543": [
       [20, 12, 6, "Unsafe array destructuring of a tuple element with an any value.", "1544266319"],

--- a/packages/extension/src/server/validator.ts
+++ b/packages/extension/src/server/validator.ts
@@ -57,8 +57,9 @@ export class BettererValidator {
 
         const loading = load(this._connection);
         let status = BettererStatus.ok;
-
+        const extensionCwd = process.cwd();
         try {
+          process.chdir(cwd);
           const config = await getBettererConfig(workspace);
           const runs = await betterer.single({ ...config, cwd }, filePath);
 
@@ -98,6 +99,8 @@ export class BettererValidator {
           } else {
             status = BettererStatus.error;
           }
+        } finally {
+          process.chdir(extensionCwd);
         }
         await loading();
         this._connection.sendNotification(BettererStatusNotification, status);


### PR DESCRIPTION
Fixes a bug where eslintrc isn't executed in the project directory, causing rulesets that use the
working directory to determine their rules to fail.

Does this by changing directory to the project before executing checks