### PR TITLE
fix(extension 🐛): can't launch VSC extension due to wrong command name

### DIFF
--- a/packages/extension/src/client/commands/names.ts
+++ b/packages/extension/src/client/commands/names.ts
@@ -2,5 +2,5 @@ export const COMMAND_NAMES = {
   disable: 'betterer.disable',
   enable: 'betterer.enable',
   init: 'betterer.init',
-  showOutput: 'betterer.showOutput'
+  showOutputChannel: 'betterer.showOutputChannel'
 };

--- a/packages/extension/src/client/extension.ts
+++ b/packages/extension/src/client/extension.ts
@@ -1,9 +1,8 @@
 import * as assert from 'assert';
 import { commands, ExtensionContext } from 'vscode';
-import { LanguageClient, CloseAction, ErrorAction, ErrorHandler } from 'vscode-languageclient';
-
+import { CloseAction, ErrorAction, ErrorHandler, LanguageClient } from 'vscode-languageclient';
 import { EXTENSION_NAME } from '../constants';
-import { disableBetterer, enableBetterer, initBetterer, COMMAND_NAMES } from './commands';
+import { COMMAND_NAMES, disableBetterer, enableBetterer, initBetterer } from './commands';
 import { CLIENT_START_FAILED, SERVER_START_FAILED } from './error-messages';
 import { error } from './logger';
 import { getClientOptions, getServerOptions } from './options';
@@ -53,7 +52,7 @@ export async function activate(context: ExtensionContext): Promise<void> {
     client.onRequest(BettererNoLibraryRequest, (params) => noLibrary(client, context, params));
 
     context.subscriptions.push(
-      commands.registerCommand(COMMAND_NAMES.showOutput, () => client.outputChannel.show()),
+      commands.registerCommand(COMMAND_NAMES.showOutputChannel, () => client.outputChannel.show()),
       started,
       status
     );

--- a/packages/extension/src/client/status.ts
+++ b/packages/extension/src/client/status.ts
@@ -1,6 +1,5 @@
-import { window, StatusBarAlignment, StatusBarItem } from 'vscode';
-import { NotificationType, LanguageClient, State } from 'vscode-languageclient';
-
+import { StatusBarAlignment, StatusBarItem, window } from 'vscode';
+import { LanguageClient, NotificationType, State } from 'vscode-languageclient';
 import { EXTENSION_NAME } from '../constants';
 import { BettererStatus } from '../status';
 import { COMMAND_NAMES } from './commands';
@@ -23,7 +22,7 @@ export class BettererStatusBar {
   constructor(client: LanguageClient) {
     this._statusBarItem = window.createStatusBarItem(StatusBarAlignment.Right, 0);
     this._statusBarItem.text = EXTENSION_NAME;
-    this._statusBarItem.command = COMMAND_NAMES.showOutput;
+    this._statusBarItem.command = COMMAND_NAMES.showOutputChannel;
     this._updateStatusBarVisibility();
 
     this._initEvents(client);


### PR DESCRIPTION
This closes https://github.com/phenomnomnominal/betterer/issues/207