### PR TITLE
fix(betterer 🐛): rename `ConstraintResult`

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ It's also pretty straightforward to write your own custom tests. All you need to
 ```typescript
 export type BettererTestOptions<T = number> = {
   test: () => T | Promise<T>;
-  constraint: (result: T, expected: T) => ConstraintResult | Promise<ConstraintResult>;
+  constraint: (result: T, expected: T) => BettererConstraintResult | Promise<BettererConstraintResult>;
   goal?: T | (result: T) => boolean;
   deadline?: Date;
 };

--- a/packages/betterer/src/runner/runner.ts
+++ b/packages/betterer/src/runner/runner.ts
@@ -1,4 +1,4 @@
-import { ConstraintResult } from '@betterer/constraints';
+import { BettererConstraintResult } from '@betterer/constraints';
 import { logError } from '@betterer/errors';
 
 import { BettererContext, BettererRun, BettererRuns } from '../context';
@@ -55,12 +55,12 @@ async function runTest(run: BettererRun): Promise<void> {
 
   const comparison = await test.constraint(result, run.expected);
 
-  if (comparison === ConstraintResult.same) {
+  if (comparison === BettererConstraintResult.same) {
     run.same(result);
     return;
   }
 
-  if (comparison === ConstraintResult.better) {
+  if (comparison === BettererConstraintResult.better) {
     run.better(result, goalComplete);
     return;
   }

--- a/packages/betterer/src/test/file-test/constraint.ts
+++ b/packages/betterer/src/test/file-test/constraint.ts
@@ -1,4 +1,4 @@
-import { ConstraintResult } from '@betterer/constraints';
+import { BettererConstraintResult } from '@betterer/constraints';
 import * as assert from 'assert';
 
 import { BettererFile } from './file';
@@ -6,33 +6,33 @@ import { BettererFiles } from './files';
 import { ensureDeserialised } from './serialiser';
 import { BettererFileTestDiff, BettererFileIssueDeserialised } from './types';
 
-type BettererFileTestConstraintResult = {
-  constraintResult: ConstraintResult;
+type BettererFileTestBettererConstraintResult = {
+  BettererConstraintResult: BettererConstraintResult;
   diff: BettererFileTestDiff;
 };
 
-export function constraint(result: BettererFiles, expected: BettererFiles): BettererFileTestConstraintResult {
+export function constraint(result: BettererFiles, expected: BettererFiles): BettererFileTestBettererConstraintResult {
   const diff = getDiff(result, expected);
 
   const filePaths = Object.keys(diff);
 
   if (filePaths.length === 0) {
-    return { constraintResult: ConstraintResult.same, diff };
+    return { BettererConstraintResult: BettererConstraintResult.same, diff };
   }
 
   const hasNew = filePaths.filter((filePath) => !!diff[filePath].neww?.length);
 
   if (hasNew.length) {
-    return { constraintResult: ConstraintResult.worse, diff };
+    return { BettererConstraintResult: BettererConstraintResult.worse, diff };
   }
 
   const hasFixed = filePaths.filter((filePath) => !!diff[filePath].fixed?.length);
 
   if (hasFixed.length) {
-    return { constraintResult: ConstraintResult.better, diff };
+    return { BettererConstraintResult: BettererConstraintResult.better, diff };
   }
 
-  return { constraintResult: ConstraintResult.same, diff };
+  return { BettererConstraintResult: BettererConstraintResult.same, diff };
 }
 
 function getDiff(result: BettererFiles, expected: BettererFiles): BettererFileTestDiff {

--- a/packages/betterer/src/test/file-test/file-test.ts
+++ b/packages/betterer/src/test/file-test/file-test.ts
@@ -1,4 +1,4 @@
-import { ConstraintResult } from '@betterer/constraints';
+import { BettererConstraintResult } from '@betterer/constraints';
 
 import { BettererRun } from '../../context';
 import { createHash } from '../../hasher';
@@ -33,7 +33,7 @@ export class BettererFileTest extends BettererTest<BettererFiles, BettererFileIs
         this._test = this._test || this._createTest(fileTest);
         return await this._test(run);
       },
-      constraint: async (result: BettererFiles, expected: BettererFiles): Promise<ConstraintResult> => {
+      constraint: async (result: BettererFiles, expected: BettererFiles): Promise<BettererConstraintResult> => {
         this._constraint = this._constraint || this._createConstraint();
         return await this._constraint(result, expected);
       },
@@ -96,10 +96,10 @@ export class BettererFileTest extends BettererTest<BettererFiles, BettererFileIs
   }
 
   private _createConstraint() {
-    return (result: BettererFiles, expected: BettererFiles): ConstraintResult => {
-      const { diff, constraintResult } = constraint(result, expected);
+    return (result: BettererFiles, expected: BettererFiles): BettererConstraintResult => {
+      const { diff, BettererConstraintResult } = constraint(result, expected);
       this._diff = diff;
-      return constraintResult;
+      return BettererConstraintResult;
     };
   }
 }

--- a/packages/betterer/src/test/types.ts
+++ b/packages/betterer/src/test/types.ts
@@ -1,4 +1,4 @@
-import { ConstraintResult } from '@betterer/constraints';
+import { BettererConstraintResult } from '@betterer/constraints';
 
 import { BettererRun } from '../context';
 import { MaybeAsync } from '../types';
@@ -11,7 +11,7 @@ export type BettererTestFunction<DeserialisedType> = (run: BettererRun) => Maybe
 export type BettererTestConstraint<DeserialisedType> = (
   result: DeserialisedType,
   expected: DeserialisedType
-) => MaybeAsync<ConstraintResult>;
+) => MaybeAsync<BettererConstraintResult>;
 
 export type BettererTestGoal<DeserialisedType> = (result: DeserialisedType) => MaybeAsync<boolean>;
 

--- a/packages/constraints/src/bigger.ts
+++ b/packages/constraints/src/bigger.ts
@@ -1,11 +1,11 @@
-import { ConstraintResult } from './constraint-result';
+import { BettererConstraintResult } from './constraint-result';
 
-export function bigger(result: number, expected: number): ConstraintResult {
+export function bigger(result: number, expected: number): BettererConstraintResult {
   if (result === expected) {
-    return ConstraintResult.same;
+    return BettererConstraintResult.same;
   }
   if (result > expected) {
-    return ConstraintResult.better;
+    return BettererConstraintResult.better;
   }
-  return ConstraintResult.worse;
+  return BettererConstraintResult.worse;
 }

--- a/packages/constraints/src/constraint-result.ts
+++ b/packages/constraints/src/constraint-result.ts
@@ -1,4 +1,4 @@
-export enum ConstraintResult {
+export enum BettererConstraintResult {
   better = 'better',
   same = 'same',
   worse = 'worse'

--- a/packages/constraints/src/index.ts
+++ b/packages/constraints/src/index.ts
@@ -1,4 +1,4 @@
-export { ConstraintResult } from './constraint-result';
+export { BettererConstraintResult } from './constraint-result';
 
 export { bigger } from './bigger';
 export { smaller } from './smaller';

--- a/packages/constraints/src/smaller.ts
+++ b/packages/constraints/src/smaller.ts
@@ -1,11 +1,11 @@
-import { ConstraintResult } from './constraint-result';
+import { BettererConstraintResult } from './constraint-result';
 
-export function smaller(result: number, expected: number): ConstraintResult {
+export function smaller(result: number, expected: number): BettererConstraintResult {
   if (result === expected) {
-    return ConstraintResult.same;
+    return BettererConstraintResult.same;
   }
   if (result < expected) {
-    return ConstraintResult.better;
+    return BettererConstraintResult.better;
   }
-  return ConstraintResult.worse;
+  return BettererConstraintResult.worse;
 }


### PR DESCRIPTION
Renames `ConstraintResult` to `BettererConstraintResult`

BREAKING CHANGE: Changes to the public API