### PR TITLE
fix(typescript 🐛): fix replacing paths in error messages

### DIFF
--- a/packages/betterer/src/test/file-test/file-resolver.ts
+++ b/packages/betterer/src/test/file-test/file-resolver.ts
@@ -50,6 +50,10 @@ export class BettererFileResolver {
     return getNormalisedPath(path.resolve(this._cwd, ...pathSegments));
   }
 
+  public forceRelativePaths(message: string): string {
+    return message.replace(new RegExp(this._cwd, 'g'), '.');
+  }
+
   private async _getValidPaths(): Promise<BettererFilePaths> {
     const resolved = await this._resolveIncludeGlobs();
     return this._filterExcludedFiles(resolved);

--- a/packages/typescript/src/typescript.ts
+++ b/packages/typescript/src/typescript.ts
@@ -62,7 +62,7 @@ export function typescript(configFilePath: string, extraCompilerOptions: ts.Comp
     return allDiagnostics.reduce((fileInfoMap, diagnostic) => {
       const { file, start, length } = diagnostic as ts.DiagnosticWithLocation;
       const { fileName } = file;
-      const message = ts.flattenDiagnosticMessageText(diagnostic.messageText, NEW_LINE).replace(process.cwd(), '.');
+      const message = resolver.forceRelativePaths(ts.flattenDiagnosticMessageText(diagnostic.messageText, NEW_LINE));
       fileInfoMap[fileName] = fileInfoMap[fileName] || [];
       fileInfoMap[fileName] = [
         ...fileInfoMap[fileName],


### PR DESCRIPTION
Fixes #209 