### PR TITLE
fix(cli 🐛): reorder betterer.single args

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -58,7 +58,7 @@ exports[`new eslint rules`] = {
       [63, 4, 71, "Promises must be handled appropriately or explicitly marked as ignored with the \`void\` operator.", "2936064845"],
       [69, 6, 27, "Promises must be handled appropriately or explicitly marked as ignored with the \`void\` operator.", "3607138074"]
     ],
-    "packages/extension/src/server/validator.ts:2557653799": [
+    "packages/extension/src/server/validator.ts:1722751911": [
       [48, 10, 90, "Promises must be handled appropriately or explicitly marked as ignored with the \`void\` operator.", "1821734533"],
       [96, 12, 94, "Promises must be handled appropriately or explicitly marked as ignored with the \`void\` operator.", "2449957056"]
     ]

--- a/packages/betterer/src/config/config.ts
+++ b/packages/betterer/src/config/config.ts
@@ -9,7 +9,7 @@ export function config(partialConfig: BettererConfigPartial): void {
   baseConfig = partialConfig;
 }
 
-export function createConfig(partialConfig: BettererConfigPartial): BettererConfig {
+export function createConfig(partialConfig: BettererConfigPartial = {}): BettererConfig {
   const relativeConfig = {
     configPaths: toArray<string>(partialConfig.configPaths || baseConfig.configPaths || ['./.betterer']),
     resultsPath: partialConfig.resultsPath || baseConfig.resultsPath || './.betterer.results',

--- a/packages/betterer/src/index.ts
+++ b/packages/betterer/src/index.ts
@@ -14,8 +14,8 @@ export * from './results/public';
 export * from './test/public';
 export * from './watcher/public';
 
-export function betterer(partialConfig: BettererConfigPartial = {}): Promise<BettererStats> {
-  return runContext(partialConfig, async (config) => {
+export function betterer(partialConfig?: BettererConfigPartial): Promise<BettererStats> {
+  return runContext(async (config) => {
     const reporter = loadReporters(config.reporters.length ? config.reporters : [DEFAULT_REPORTER]);
     const context = new BettererContext(config, reporter);
     await context.setup();
@@ -23,24 +23,24 @@ export function betterer(partialConfig: BettererConfigPartial = {}): Promise<Bet
     const stats = await context.process(runs);
     context.tearDown();
     return stats;
-  });
+  }, partialConfig);
 }
 
 betterer.single = async function bettererSingle(
-  partialConfig: BettererConfigPartial = {},
-  filePath: string
+  filePath: string,
+  partialConfig?: BettererConfigPartial
 ): Promise<BettererRuns> {
-  return runContext(partialConfig, async (config) => {
+  return runContext(async (config) => {
     const context = new BettererContext(config);
     await context.setup();
     const runs = await parallel(context, [filePath]);
     context.tearDown();
     return runs;
-  });
+  }, partialConfig);
 };
 
-betterer.watch = function bettererWatch(partialConfig: BettererConfigPartial = {}): Promise<BettererWatcher> {
-  return runContext(partialConfig, async (config) => {
+betterer.watch = function bettererWatch(partialConfig?: BettererConfigPartial): Promise<BettererWatcher> {
+  return runContext(async (config) => {
     const reporter = loadReporters(config.reporters.length ? config.reporters : [WATCH_REPORTER]);
     const context = new BettererContext(config, reporter);
     const watcher = new BettererWatcher(context, async (filePaths) => {
@@ -49,12 +49,12 @@ betterer.watch = function bettererWatch(partialConfig: BettererConfigPartial = {
     });
     await watcher.setup();
     return watcher;
-  });
+  }, partialConfig);
 };
 
 async function runContext<RunResult, RunFunction extends (config: BettererConfig) => Promise<RunResult>>(
-  partialConfig: BettererConfigPartial,
-  run: RunFunction
+  run: RunFunction,
+  partialConfig?: BettererConfigPartial
 ): Promise<RunResult> {
   try {
     const config = createConfig(partialConfig);

--- a/packages/extension/src/server/validator.ts
+++ b/packages/extension/src/server/validator.ts
@@ -61,7 +61,7 @@ export class BettererValidator {
         try {
           process.chdir(cwd);
           const config = await getBettererConfig(workspace);
-          const runs = await betterer.single({ ...config, cwd }, filePath);
+          const runs = await betterer.single(filePath, { ...config, cwd });
 
           runs
             .filter((run) => !run.isFailed)

--- a/test/betterer-failed.spec.ts
+++ b/test/betterer-failed.spec.ts
@@ -87,7 +87,7 @@ module.exports = {
     await writeFile(resultsPath, 'throw new Error()');
 
     await expect(async () => await betterer({ configPaths, resultsPath })).rejects.toThrow();
-    await expect(async () => await betterer.single({ configPaths, resultsPath }, indexPath)).rejects.toThrow();
+    await expect(async () => await betterer.single(indexPath, { configPaths, resultsPath })).rejects.toThrow();
 
     expect(logs).toMatchSnapshot();
 

--- a/test/single/betterer-single.spec.ts
+++ b/test/single/betterer-single.spec.ts
@@ -49,7 +49,7 @@ module.exports = {
 
     await writeFile(indexPath, `debugger;`);
 
-    const [run] = await betterer.single({ configPaths, resultsPath, cwd }, indexPath);
+    const [run] = await betterer.single(indexPath, { configPaths, resultsPath, cwd });
 
     expect(run.isNew).toEqual(true);
     expect(run.files).toEqual([indexPath]);
@@ -103,7 +103,7 @@ module.exports = {
 
     await writeFile(testFile, `debugger;`);
 
-    const [run] = await betterer.single({ configPaths, resultsPath, cwd }, testFile);
+    const [run] = await betterer.single(testFile, { configPaths, resultsPath, cwd });
 
     expect(run.isComplete).toEqual(true);
     expect(run.files).toEqual([testFile]);
@@ -129,7 +129,7 @@ module.exports = {
 
     await writeFile(indexPath, `// HACK:`);
 
-    const [run] = await betterer.single({ configPaths, resultsPath, cwd }, indexPath);
+    const [run] = await betterer.single(indexPath, { configPaths, resultsPath, cwd });
 
     expect(run.isNew).toEqual(true);
     expect(run.files).toEqual([indexPath]);
@@ -155,7 +155,7 @@ module.exports = {
 
     await writeFile(testFile, `// HACK:`);
 
-    const [run] = await betterer.single({ configPaths, resultsPath, cwd }, testFile);
+    const [run] = await betterer.single(testFile, { configPaths, resultsPath, cwd });
 
     expect(run.isComplete).toEqual(true);
     expect(run.files).toEqual([testFile]);
@@ -197,7 +197,7 @@ export default {
 
     await writeFile(indexPath, `console.log('foo');`);
 
-    const [run] = await betterer.single({ configPaths, resultsPath, cwd }, indexPath);
+    const [run] = await betterer.single(indexPath, { configPaths, resultsPath, cwd });
 
     expect(run.isNew).toEqual(true);
     expect(run.files).toEqual([indexPath]);
@@ -239,7 +239,7 @@ export default {
 
     await writeFile(testPath, `console.log('foo');`);
 
-    const [run] = await betterer.single({ configPaths, resultsPath, cwd }, testPath);
+    const [run] = await betterer.single(testPath, { configPaths, resultsPath, cwd });
 
     expect(run.isNew).toEqual(true);
     expect(run.files).toEqual([testPath]);
@@ -280,7 +280,7 @@ export default {
 
     await writeFile(indexPath, `const a = 'a';\nconst one = 1;\nconsole.log(a * one);`);
 
-    const [run] = await betterer.single({ configPaths, resultsPath, cwd }, indexPath);
+    const [run] = await betterer.single(indexPath, { configPaths, resultsPath, cwd });
 
     expect(run.isNew).toEqual(true);
     expect(run.files).toEqual([indexPath]);
@@ -321,7 +321,7 @@ export default {
 
     await writeFile(testPath, `const a = 'a';\nconst one = 1;\nconsole.log(a * one);`);
 
-    const [run] = await betterer.single({ configPaths, resultsPath, cwd }, testPath);
+    const [run] = await betterer.single(testPath, { configPaths, resultsPath, cwd });
 
     expect(run.isNew).toEqual(true);
     expect(run.files).toEqual([testPath]);


### PR DESCRIPTION
Make the `filePath` the first argument.

BREAKING CHANGE: Changes to the public API