### PR TITLE
fix(errors 🐛): explicitly mark private exports from @betterer/errors

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -4,7 +4,7 @@ exports[`no hack comments`] = {
     "packages/cli/src/cli.ts:2275900736": [
       [12, 0, 7, "RegExp match", "645651780"]
     ],
-    "packages/cli/src/init.ts:2248997325": [
+    "packages/cli/src/init.ts:465515789": [
       [92, 4, 7, "RegExp match", "645651780"]
     ]
   }`

--- a/packages/betterer/src/index.ts
+++ b/packages/betterer/src/index.ts
@@ -1,4 +1,4 @@
-import { logError } from '@betterer/errors';
+import { logErrorΔ } from '@betterer/errors';
 
 import { BettererConfig, BettererConfigPartial, createConfig } from './config';
 import { BettererContext, BettererStats, BettererRuns } from './context';
@@ -61,7 +61,7 @@ async function runContext<RunResult, RunFunction extends (config: BettererConfig
     registerExtensions(config);
     return await run(config);
   } catch (e) {
-    logError(e);
+    logErrorΔ(e);
     throw e;
   }
 }

--- a/packages/betterer/src/runner/runner.ts
+++ b/packages/betterer/src/runner/runner.ts
@@ -1,5 +1,5 @@
 import { BettererConstraintResult } from '@betterer/constraints';
-import { logError } from '@betterer/errors';
+import { logErrorΔ } from '@betterer/errors';
 
 import { BettererContext, BettererRun, BettererRuns } from '../context';
 import { BettererFilePaths } from '../watcher';
@@ -41,7 +41,7 @@ async function runTest(run: BettererRun): Promise<void> {
     result = await test.test(run);
   } catch (e) {
     run.failed();
-    logError(e);
+    logErrorΔ(e);
     return;
   }
   run.ran();

--- a/packages/cli/src/init.ts
+++ b/packages/cli/src/init.ts
@@ -1,4 +1,4 @@
-import { logError } from '@betterer/errors';
+import { logErrorΔ } from '@betterer/errors';
 import { infoΔ, warnΔ, successΔ } from '@betterer/logger';
 import * as commander from 'commander';
 import * as findUp from 'find-up';
@@ -32,7 +32,7 @@ export async function initΔ(cwd: string, argv: BettererCLIArguments): Promise<v
     await createTestFile(cwd, config);
     await updatePackageJSON(cwd);
   } catch (e) {
-    logError(e);
+    logErrorΔ(e);
     throw e;
   }
   successΔ('initialised Betterer! ☀️');

--- a/packages/errors/README.md
+++ b/packages/errors/README.md
@@ -20,16 +20,18 @@ const MY_ERROR = registerError((details) => `Something went wrong: ${details}`);
 
 ### Log Error
 
+> ## 🚨🚨🚨 THIS FUNCTION SHOULD ONLY BE USED WITHIN THE BETTERER MONOREPO 🚨🚨🚨
+
 Log a registered error type:
 
 ```typescript
-import { logError, registerError } from '@betterer/errors';
+import { logErrorΔ, registerError } from '@betterer/errors';
 
 const MY_ERROR = registerError(details => `Something went wrong: "${details}"`);
 
 try {
     throw MY_ERROR('OOPS!):
 } catch (e) {
-    logError(e); // 'Something went wrong: "OOPS"'
+    logErrorΔ(e); // 'Something went wrong: "OOPS"'
 }
 ```

--- a/packages/errors/src/error-handler.ts
+++ b/packages/errors/src/error-handler.ts
@@ -1,18 +1,24 @@
 import { brΔ, errorΔ } from '@betterer/logger';
 
-import { BettererError } from './error';
-import { BettererErrorDetails, BettererErrorFactory, BettererErrorMessageFactory, ErrorLike } from './types';
+import { BettererErrorΩ } from './error';
+import {
+  BettererError,
+  BettererErrorDetails,
+  BettererErrorFactory,
+  BettererErrorMessageFactory,
+  ErrorLike
+} from './types';
 
 const ERROR_MESSAGES = new Map<symbol, BettererErrorMessageFactory>();
 
-export function logError(err: ErrorLike | Error | BettererError): void {
+export function logErrorΔ(err: ErrorLike | Error | BettererError): void {
   if (isBettererError(err)) {
     const factory = ERROR_MESSAGES.get(err.code) as BettererErrorMessageFactory;
     const errors = err.details.filter((detail) => isErrorLike(detail)) as Array<ErrorLike>;
     const messages = err.details.filter((detail) => !errors.includes(detail as ErrorLike)) as Array<string>;
     err.message = factory(...messages);
     errorΔ(err.message);
-    errors.forEach(logError);
+    errors.forEach(logErrorΔ);
     return;
   }
   brΔ();
@@ -25,7 +31,7 @@ export function registerError(factory: BettererErrorMessageFactory): BettererErr
   const code = Symbol();
   ERROR_MESSAGES.set(code, factory);
   return function factory(...details: BettererErrorDetails): BettererError {
-    const error = new BettererError(code, ...details);
+    const error = new BettererErrorΩ(code, ...details);
     Error.captureStackTrace(error, factory);
     return error;
   };

--- a/packages/errors/src/error.ts
+++ b/packages/errors/src/error.ts
@@ -1,12 +1,12 @@
-import { BettererErrorDetails } from './types';
+import { BettererErrorDetails, BettererError } from './types';
 
-export class BettererError extends Error {
+export class BettererErrorΩ extends Error implements BettererError {
   public details: BettererErrorDetails;
 
   constructor(public code: symbol, ...details: BettererErrorDetails) {
     super();
 
-    Error.captureStackTrace(this, BettererError);
+    Error.captureStackTrace(this, BettererErrorΩ);
     Object.setPrototypeOf(this, new.target.prototype);
 
     this.details = details;

--- a/packages/errors/src/index.ts
+++ b/packages/errors/src/index.ts
@@ -1,3 +1,8 @@
-export { BettererError } from './error';
-export { logError, registerError } from './error-handler';
-export * from './types';
+export { logErrorΔ, registerError } from './error-handler';
+export {
+  BettererError,
+  BettererErrorDetails,
+  BettererErrorFactory,
+  BettererErrorMessageFactory,
+  ErrorLike
+} from './types';

--- a/packages/errors/src/types.ts
+++ b/packages/errors/src/types.ts
@@ -1,4 +1,7 @@
-import { BettererError } from './error';
+export type BettererError = Error & {
+  code: symbol;
+  details: BettererErrorDetails;
+};
 
 export type BettererErrorDetails = ReadonlyArray<string | Error | BettererError>;
 export type BettererErrorFactory = (...details: BettererErrorDetails) => BettererError;

--- a/packages/reporter/src/utils.ts
+++ b/packages/reporter/src/utils.ts
@@ -1,8 +1,8 @@
 import { BettererContext } from '@betterer/betterer';
-import { BettererError, logError } from '@betterer/errors';
+import { BettererError, logErrorΔ } from '@betterer/errors';
 
 export function contextErrorΔ(_: BettererContext, error: BettererError, printed: Array<string>): void {
-  logError(error);
+  logErrorΔ(error);
   process.stdout.write(printed.join(''));
 }
 


### PR DESCRIPTION
Mark private exports with Δ

BREAKING CHANGE: Changes to the public API