### PR TITLE
fix(betterer 🐛): more name from test to run

### DIFF
--- a/goldens/api/@betterer/betterer.d.ts
+++ b/goldens/api/@betterer/betterer.d.ts
@@ -121,6 +121,7 @@ export declare type BettererReporterNames = ReadonlyArray<string>;
 export declare type BettererRun = {
     readonly expected: unknown | typeof NO_PREVIOUS_RESULT;
     readonly files: BettererFilePaths;
+    readonly name: string;
     readonly result: unknown;
     readonly shouldPrint: boolean;
     readonly test: BettererTest;
@@ -166,12 +167,10 @@ export declare class BettererTest<DeserialisedType = unknown, SerialisedType = D
     differ?: BettererDiffer;
     readonly goal: BettererTestGoal<DeserialisedType>;
     isBettererTest: string;
-    get name(): string;
     printer?: BettererPrinter<SerialisedType>;
     serialiser?: BettererSerialiser<DeserialisedType, SerialisedType>;
     readonly test: BettererTestFunction<DeserialisedType>;
     constructor(options: BettererTestOptions<DeserialisedType, SerialisedType>);
-    setName(name: string): void;
 }
 
 export declare type BettererTestConstraint<DeserialisedType> = (result: DeserialisedType, expected: DeserialisedType) => MaybeAsync<BettererConstraintResult>;
@@ -182,7 +181,7 @@ export declare type BettererTestGoal<DeserialisedType> = (result: DeserialisedTy
 
 export declare type BettererTestNames = Array<string>;
 
-export declare type BettererTestOptions<DeserialisedType, SerialisedType = DeserialisedType> = {
+export declare type BettererTestOptions<DeserialisedType = unknown, SerialisedType = DeserialisedType> = {
     constraint: BettererTestConstraint<DeserialisedType>;
     deadline?: Date | string;
     goal?: DeserialisedType | BettererTestGoal<DeserialisedType>;

--- a/packages/betterer/src/context/run.ts
+++ b/packages/betterer/src/context/run.ts
@@ -32,6 +32,7 @@ export class BettererRunΩ implements BettererRun {
 
   constructor(
     private readonly _context: BettererContextΩ,
+    private readonly _name: string,
     private readonly _test: BettererTest,
     expected: BettererExpectedResult | typeof NO_PREVIOUS_RESULT,
     private readonly _files: BettererFilePaths
@@ -45,6 +46,10 @@ export class BettererRunΩ implements BettererRun {
       this._toPrint = this._expected;
       this._hasResult = true;
     }
+  }
+
+  public get name(): string {
+    return this._name;
   }
 
   public get expected(): unknown | typeof NO_PREVIOUS_RESULT {

--- a/packages/betterer/src/context/types.ts
+++ b/packages/betterer/src/context/types.ts
@@ -15,6 +15,7 @@ export type BettererContext = {
 export type BettererRun = {
   readonly expected: unknown | typeof NO_PREVIOUS_RESULT;
   readonly files: BettererFilePaths;
+  readonly name: string;
   readonly result: unknown;
   readonly shouldPrint: boolean;
   readonly test: BettererTest;

--- a/packages/betterer/src/results/deserialiser.ts
+++ b/packages/betterer/src/results/deserialiser.ts
@@ -1,6 +1,6 @@
-import { BettererRun } from '../context';
+import { BettererRunΩ } from '../context';
 
-export function deserialise(run: BettererRun, serialised: string): unknown {
+export function deserialise(run: BettererRunΩ, serialised: string): unknown {
   const { test } = run;
   const parsed = JSON.parse(serialised) as unknown;
   const deserialiser = test.serialiser?.deserialise || defaultDeserialiser;

--- a/packages/betterer/src/results/printer.ts
+++ b/packages/betterer/src/results/printer.ts
@@ -8,11 +8,11 @@ import { serialise } from './serialiser';
 const UNESCAPED = '"\n';
 
 export async function print(run: BettererRunΩ): Promise<string> {
-  const { test } = run;
+  const { test, name } = run;
   const printer = test.printer || defaultPrinter;
   const printedValue = await printer(run, serialise(run));
   const escaped = escape(printedValue, UNESCAPED);
-  return `\nexports[\`${test.name}\`] = {\n  value: \`${escaped}\`\n};\n`;
+  return `\nexports[\`${name}\`] = {\n  value: \`${escaped}\`\n};\n`;
 }
 
 function defaultPrinter(_: BettererRunΩ, value: unknown): string {

--- a/packages/betterer/src/test/index.ts
+++ b/packages/betterer/src/test/index.ts
@@ -26,6 +26,6 @@ export {
   BettererTestFunction,
   BettererTestGoal,
   BettererTestMap,
-  BettererTestOptions,
-  BettererTests
+  BettererTestOptionsMap,
+  BettererTestOptions
 } from './types';

--- a/packages/betterer/src/test/test.ts
+++ b/packages/betterer/src/test/test.ts
@@ -1,5 +1,3 @@
-import * as assert from 'assert';
-
 import { CONSTRAINT_FUNCTION_REQUIRED, TEST_FUNCTION_REQUIRED } from '../errors';
 import { isFunction } from '../utils';
 import {
@@ -27,8 +25,6 @@ export class BettererTest<DeserialisedType = unknown, SerialisedType = Deseriali
 
   public isBettererTest = IS_BETTERER_TEST;
 
-  private _name: string | null = null;
-
   constructor(options: BettererTestOptions<DeserialisedType, SerialisedType>) {
     super(options.isSkipped, options.isOnly);
 
@@ -47,15 +43,6 @@ export class BettererTest<DeserialisedType = unknown, SerialisedType = Deseriali
     this.differ = options.differ;
     this.printer = options.printer;
     this.serialiser = options.serialiser;
-  }
-
-  public setName(name: string): void {
-    this._name = name;
-  }
-
-  public get name(): string {
-    assert.notStrictEqual(this._name, null);
-    return this._name as string;
   }
 
   private _createDeadline(options: BettererTestOptions<DeserialisedType, SerialisedType>): number {

--- a/packages/betterer/src/test/types.ts
+++ b/packages/betterer/src/test/types.ts
@@ -4,8 +4,6 @@ import { BettererRun } from '../context';
 import { MaybeAsync } from '../types';
 import { BettererTest } from './test';
 
-export type BettererTests = ReadonlyArray<BettererTest>;
-
 export type BettererTestFunction<DeserialisedType> = (run: BettererRun) => MaybeAsync<DeserialisedType>;
 
 export type BettererTestConstraint<DeserialisedType> = (
@@ -37,7 +35,7 @@ export type BettererTestStateOptions = {
   isSkipped?: boolean;
 };
 
-export type BettererTestOptions<DeserialisedType, SerialisedType = DeserialisedType> = {
+export type BettererTestOptions<DeserialisedType = unknown, SerialisedType = DeserialisedType> = {
   constraint: BettererTestConstraint<DeserialisedType>;
   deadline?: Date | string;
   goal?: DeserialisedType | BettererTestGoal<DeserialisedType>;
@@ -47,4 +45,5 @@ export type BettererTestOptions<DeserialisedType, SerialisedType = DeserialisedT
   serialiser?: BettererSerialiser<DeserialisedType, SerialisedType>;
 } & BettererTestStateOptions;
 
-export type BettererTestMap = Record<string, BettererTest | BettererTestOptions<unknown, unknown>>;
+export type BettererTestMap = Record<string, BettererTest>;
+export type BettererTestOptionsMap = Record<string, BettererTest | BettererTestOptions>;

--- a/packages/reporter/src/reporter.ts
+++ b/packages/reporter/src/reporter.ts
@@ -75,14 +75,14 @@ export const defaultReporter: BettererReporter = {
   },
   contextError: contextErrorΔ,
   runStart(run: BettererRun): void {
-    const name = quoteΔ(run.test.name);
+    const name = quoteΔ(run.name);
     if (run.isExpired) {
       errorΔ(testExpiredΔ(name));
     }
     infoΔ(testRunningΔ(name));
   },
   runEnd(run: BettererRun): void {
-    const name = quoteΔ(run.test.name);
+    const name = quoteΔ(run.name);
     if (run.isComplete) {
       successΔ(testCompleteΔ(name, run.isNew));
       return;

--- a/packages/watch-reporter/src/reporter.ts
+++ b/packages/watch-reporter/src/reporter.ts
@@ -33,7 +33,7 @@ export const watchReporter: BettererReporter = {
     });
     report += '\n';
     runs.forEach((run) => {
-      const name = quoteΔ(run.test.name);
+      const name = quoteΔ(run.name);
       if (run.isBetter) {
         report += `\n  ${testBetterΔ(name)}`;
         return;


### PR DESCRIPTION
Move `name` from BettererTest to BettererRun

BREAKING CHANGE: Changes to the public API