### PR TITLE
fix(eslint 🐛): fix no-floating-promises errors

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -24,43 +24,6 @@ exports[`new eslint rules`] = {
     ],
     "packages/cli/src/errors.ts:4053971182": [
       [2, 90, 10, "Invalid type \\"string | Error | BettererError\\" of template literal expression.", "3805115554"]
-    ],
-    "packages/cli/src/watch.ts:176597381": [
-      [26, 6, 15, "Promises must be handled appropriately or explicitly marked as ignored with the \`void\` operator.", "733721943"]
-    ],
-    "packages/extension/src/client/commands/disable.ts:1676199082": [
-      [11, 4, 42, "Promises must be handled appropriately or explicitly marked as ignored with the \`void\` operator.", "829060112"],
-      [17, 4, 41, "Promises must be handled appropriately or explicitly marked as ignored with the \`void\` operator.", "2714035641"]
-    ],
-    "packages/extension/src/client/commands/enable.ts:240861284": [
-      [11, 4, 41, "Promises must be handled appropriately or explicitly marked as ignored with the \`void\` operator.", "3801738949"],
-      [17, 4, 40, "Promises must be handled appropriately or explicitly marked as ignored with the \`void\` operator.", "2505016204"]
-    ],
-    "packages/extension/src/client/commands/init.ts:2622237704": [
-      [14, 4, 39, "Promises must be handled appropriately or explicitly marked as ignored with the \`void\` operator.", "2731829246"],
-      [24, 4, 43, "Promises must be handled appropriately or explicitly marked as ignored with the \`void\` operator.", "4071897381"]
-    ],
-    "packages/extension/src/client/extension.ts:2763828744": [
-      [59, 4, 27, "Promises must be handled appropriately or explicitly marked as ignored with the \`void\` operator.", "1648678109"]
-    ],
-    "packages/extension/src/client/requests/state.ts:545404786": [
-      [23, 4, 48, "Promises must be handled appropriately or explicitly marked as ignored with the \`void\` operator.", "3664587686"]
-    ],
-    "packages/extension/src/client/settings.ts:3918432042": [
-      [23, 2, 40, "Promises must be handled appropriately or explicitly marked as ignored with the \`void\` operator.", "2460760654"]
-    ],
-    "packages/extension/src/client/status.ts:2071927473": [
-      [27, 4, 25, "Promises must be handled appropriately or explicitly marked as ignored with the \`void\` operator.", "3494514196"],
-      [73, 6, 32, "Promises must be handled appropriately or explicitly marked as ignored with the \`void\` operator.", "694099710"]
-    ],
-    "packages/extension/src/server/server.ts:2004201515": [
-      [62, 4, 68, "Promises must be handled appropriately or explicitly marked as ignored with the \`void\` operator.", "280309533"],
-      [63, 4, 71, "Promises must be handled appropriately or explicitly marked as ignored with the \`void\` operator.", "2936064845"],
-      [69, 6, 27, "Promises must be handled appropriately or explicitly marked as ignored with the \`void\` operator.", "3607138074"]
-    ],
-    "packages/extension/src/server/validator.ts:2557653799": [
-      [48, 10, 90, "Promises must be handled appropriately or explicitly marked as ignored with the \`void\` operator.", "1821734533"],
-      [96, 12, 94, "Promises must be handled appropriately or explicitly marked as ignored with the \`void\` operator.", "2449957056"]
     ]
   }`
 };

--- a/packages/betterer/src/test/file-test/file.ts
+++ b/packages/betterer/src/test/file-test/file.ts
@@ -1,11 +1,6 @@
 import * as assert from 'assert';
 
-import {
-  BettererFileIssues,
-  BettererFileIssueRaw,
-  BettererFileIssuesRaw,
-  BettererFileIssuesDeserialised
-} from './types';
+import { BettererFileIssues, BettererFileIssuesRaw, BettererFileIssuesDeserialised } from './types';
 
 export class BettererFile {
   public readonly key: string;
@@ -41,5 +36,5 @@ export class BettererFile {
 
 function isRaw(issues: BettererFileIssues): issues is BettererFileIssuesRaw {
   const [issue] = issues;
-  return (issue as BettererFileIssueRaw).fileText != null;
+  return 'fileText' in issue && issue.fileText != null;
 }

--- a/packages/cli/src/watch.ts
+++ b/packages/cli/src/watch.ts
@@ -24,7 +24,7 @@ export async function watch(cwd: string, argv: CLIArguments): Promise<void> {
 
   return new Promise((): void => {
     process.on('SIGINT', () => {
-      watcher.stop();
+      void watcher.stop();
     });
   });
 }

--- a/packages/extension/src/client/commands/disable.ts
+++ b/packages/extension/src/client/commands/disable.ts
@@ -9,13 +9,13 @@ import { pickFolder } from './folder-picker';
 export async function disableBetterer(): Promise<void> {
   const { workspaceFolders } = workspace;
   if (!workspaceFolders) {
-    error(DISABLE_COMMAND_REQUIRES_WORKSPACE);
+    void error(DISABLE_COMMAND_REQUIRES_WORKSPACE);
     return;
   }
 
   const enabledFolders = workspaceFolders.filter((folder) => getEnabled(folder));
   if (enabledFolders.length === 0) {
-    info(ALREADY_DISABLED(workspaceFolders));
+    void info(ALREADY_DISABLED(workspaceFolders));
     return;
   }
 

--- a/packages/extension/src/client/commands/enable.ts
+++ b/packages/extension/src/client/commands/enable.ts
@@ -9,13 +9,13 @@ import { pickFolder } from './folder-picker';
 export async function enableBetterer(): Promise<void> {
   const { workspaceFolders } = workspace;
   if (!workspaceFolders) {
-    error(ENABLE_COMMAND_REQUIRES_WORKSPACE);
+    void error(ENABLE_COMMAND_REQUIRES_WORKSPACE);
     return;
   }
 
   const disabledFolders = workspaceFolders.filter((folder) => !getEnabled(folder));
   if (disabledFolders.length === 0) {
-    info(ALREADY_ENABLED(workspaceFolders));
+    void info(ALREADY_ENABLED(workspaceFolders));
     return;
   }
 

--- a/packages/extension/src/client/commands/init.ts
+++ b/packages/extension/src/client/commands/init.ts
@@ -12,7 +12,7 @@ const CONFIG_FILES = ['.betterer.ts', '.betterer.js'];
 export async function initBetterer(): Promise<void> {
   const { workspaceFolders } = workspace;
   if (!workspaceFolders) {
-    error(INIT_COMMAND_REQUIRES_WORKSPACE);
+    void error(INIT_COMMAND_REQUIRES_WORKSPACE);
     return;
   }
 
@@ -22,7 +22,7 @@ export async function initBetterer(): Promise<void> {
     })
   );
   if (foldersWithoutConfig.length === 0) {
-    info(ALREADY_CONFIGURED(workspaceFolders));
+    void info(ALREADY_CONFIGURED(workspaceFolders));
     return;
   }
 

--- a/packages/extension/src/client/extension.ts
+++ b/packages/extension/src/client/extension.ts
@@ -57,6 +57,6 @@ export async function activate(context: ExtensionContext): Promise<void> {
       status
     );
   } catch {
-    error(CLIENT_START_FAILED);
+    void error(CLIENT_START_FAILED);
   }
 }

--- a/packages/extension/src/client/requests/state.ts
+++ b/packages/extension/src/client/requests/state.ts
@@ -21,7 +21,7 @@ function getState(key: string) {
     const workspaceUri = workspaceFolder.uri.toString();
     const result = workspaces[workspaceUri];
     workspaces[workspaceUri] = true;
-    context.globalState.update(key, { workspaces });
+    void context.globalState.update(key, { workspaces });
     return result;
   };
 }

--- a/packages/extension/src/client/settings.ts
+++ b/packages/extension/src/client/settings.ts
@@ -21,7 +21,7 @@ export function disable(item: { uri: Uri }): void {
 }
 
 function updateEnabled(item: { uri: Uri }, value: boolean): void {
-  getConfig(item).update('enable', value);
+  void getConfig(item).update('enable', value);
 }
 
 function getConfig(item: { uri: Uri }): WorkspaceConfiguration {

--- a/packages/extension/src/client/status.ts
+++ b/packages/extension/src/client/status.ts
@@ -25,7 +25,7 @@ export class BettererStatusBar {
     this._statusBarItem.command = COMMAND_NAMES.showOutputChannel;
     this._updateStatusBarVisibility();
 
-    this._initEvents(client);
+    void this._initEvents(client);
   }
 
   public get hasExited(): boolean {
@@ -71,7 +71,7 @@ export class BettererStatusBar {
       this._exit();
       const [code, message] = params;
       client.error(SERVER_PROCESS_ENDED(code), message, true);
-      error(SERVER_PROCESS_SHUT_DOWN);
+      void error(SERVER_PROCESS_SHUT_DOWN);
     });
   }
 

--- a/packages/extension/src/server/server.ts
+++ b/packages/extension/src/server/server.ts
@@ -60,14 +60,14 @@ function init(): void {
   connection.onNotification(DidChangeWatchedFilesNotification.type, environmentChanged);
 
   connection.onInitialized(() => {
-    connection.client.register(DidChangeConfigurationNotification.type);
-    connection.client.register(DidChangeWorkspaceFoldersNotification.type);
+    void connection.client.register(DidChangeConfigurationNotification.type);
+    void connection.client.register(DidChangeWorkspaceFoldersNotification.type);
   });
 
   validationQueue.onNotification(
     BettererValidateNotification,
     (document) => {
-      validator.single(document);
+      void validator.single(document);
     },
     (document) => document.version
   );

--- a/packages/extension/src/server/validator.ts
+++ b/packages/extension/src/server/validator.ts
@@ -46,7 +46,7 @@ export class BettererValidator {
         try {
           betterer = await getLibrary(cwd);
         } catch {
-          this._connection.sendRequest(BettererNoLibraryRequest, { source: { uri: document.uri } });
+          void this._connection.sendRequest(BettererNoLibraryRequest, { source: { uri: document.uri } });
           return;
         }
       }
@@ -94,7 +94,7 @@ export class BettererValidator {
           this._connection.sendDiagnostics({ uri, diagnostics });
         } catch (e) {
           if (isNoConfigError(e)) {
-            this._connection.sendRequest(BettererInvalidConfigRequest, { source: { uri: document.uri } });
+            void this._connection.sendRequest(BettererInvalidConfigRequest, { source: { uri: document.uri } });
             status = BettererStatus.warn;
           } else {
             status = BettererStatus.error;


### PR DESCRIPTION
I fixed the `no-floating-promises` errors by marking the promises as ignored with the `void` operator.

Issue: https://github.com/phenomnomnominal/betterer/issues/116