### PR TITLE
[typescript] Prevent error when there is no location for diagnostic

### DIFF
--- a/packages/typescript/src/typescript.ts
+++ b/packages/typescript/src/typescript.ts
@@ -60,7 +60,11 @@ export function typescript(configFilePath: string, extraCompilerOptions: ts.Comp
     ]);
 
     return allDiagnostics.reduce((fileInfoMap, diagnostic) => {
-      const { file, start, length } = diagnostic as ts.DiagnosticWithLocation;
+      const { file, start, length } = diagnostic;
+      // If there is no location, skip it
+      if (file === undefined || start === undefined || length === undefined) {
+        return fileInfoMap;
+      }
       const { fileName } = file;
       const message = resolver.forceRelativePaths(ts.flattenDiagnosticMessageText(diagnostic.messageText, NEW_LINE));
       fileInfoMap[fileName] = fileInfoMap[fileName] || [];


### PR DESCRIPTION
Hi everyone!

I think Betterer looks like a good idea so I wanted to try it. Sadly I ran with our tsconfig.json into an error while using @betterer/typescript.

```
TypeError: Cannot read property 'fileName' of undefined
    at [..]\node_modules\@betterer\typescript\src\typescript.ts:69:9
    at Array.reduce (<anonymous>)
    at Object.<anonymous> ([..]\node_modules\@betterer\typescript\src\typescript.ts:62:27)
    at step ([..]\node_modules\tslib\tslib.js:140:27)
    at Object.next ([..]\node_modules\tslib\tslib.js:121:57)
    at fulfilled ([..]\node_modules\tslib\tslib.js:111:62)
```

The diagnostics object in the reduce callback looks like this:

```
{ file: undefined,
  start: undefined,
  length: undefined,
  messageText:
   'Option \'--incremental\' can only be specified using tsconfig, emitting to single file or when option `--tsBuildInfoFile` is specified.',
  category: 1,
  code: 5074,
  reportsUnnecessary: undefined }
```

I therefore improved typesafety a bit and let the reduce skip such messages. This should be a fix for my problem, but maybe it would be better to print those messages somehow, but I don't know how to do it best.