### PR TITLE
Report issues from all runs in VS Code extension

### DIFF
--- a/packages/extension/src/server/validator.ts
+++ b/packages/extension/src/server/validator.ts
@@ -110,48 +110,48 @@ export class BettererValidator {
 
     const diagnostics: Array<Diagnostic> = [];
 
-    const { runs } = summary;
-    const run = runs[runs.length - 1];
-    if (run.isFailed) {
-      return;
-    }
+    summary.runs.forEach((run) => {
+      if (run.isFailed) {
+        return;
+      }
 
-    const result = run.result.value as BettererFileTestResult;
-    if (!result) {
-      return;
-    }
+      const result = run.result.value as BettererFileTestResult;
+      if (!result) {
+        return;
+      }
 
-    let issues: BettererFileIssues;
-    try {
-      issues = result.getIssues(filePath);
-    } catch {
-      return;
-    }
+      let issues: BettererFileIssues;
+      try {
+        issues = result.getIssues(filePath);
+      } catch {
+        return;
+      }
 
-    info(`Validator: Got issues from Betterer for "${run.name}"`);
+      info(`Validator: Got issues from Betterer for "${run.name}"`);
 
-    let existingIssues: BettererFileIssues = [];
-    let newIssues: BettererFileIssues = [];
+      let existingIssues: BettererFileIssues = [];
+      let newIssues: BettererFileIssues = [];
 
-    if (run.isNew) {
-      newIssues = issues;
-    } else if (run.isSkipped || run.isSame) {
-      existingIssues = issues;
-    } else {
-      const fileDiff = ((run.diff as unknown) as BettererFileTestDiff).diff[filePath];
-      info(`Validator: Got diff from Betterer for "${filePath}"`);
-      existingIssues = fileDiff.existing || [];
-      newIssues = fileDiff.new || [];
-    }
+      if (run.isNew) {
+        newIssues = issues;
+      } else if (run.isSkipped || run.isSame) {
+        existingIssues = issues;
+      } else {
+        const fileDiff = ((run.diff as unknown) as BettererFileTestDiff).diff[filePath];
+        info(`Validator: ${run.name} got diff from Betterer for "${filePath}"`);
+        existingIssues = fileDiff.existing || [];
+        newIssues = fileDiff.new || [];
+      }
 
-    info(`Validator: Got "${existingIssues.length}" existing issues for "${filePath}"`);
-    info(`Validator: Got "${newIssues.length}" new issues for "${filePath}"`);
+      info(`Validator: ${run.name} got "${existingIssues.length}" existing issues for "${filePath}"`);
+      info(`Validator: ${run.name} got "${newIssues.length}" new issues for "${filePath}"`);
 
-    existingIssues.forEach((issue: BettererFileIssue) => {
-      diagnostics.push(createWarning(run.name, 'existing issue', issue, document));
-    });
-    newIssues.forEach((issue) => {
-      diagnostics.push(createError(run.name, 'new issue', issue, document));
+      existingIssues.forEach((issue: BettererFileIssue) => {
+        diagnostics.push(createWarning(run.name, 'existing issue', issue, document));
+      });
+      newIssues.forEach((issue) => {
+        diagnostics.push(createError(run.name, 'new issue', issue, document));
+      });
     });
 
     const { uri } = document;


### PR DESCRIPTION
This combines the issues found from all runs into one set of diagnostics to pass to VS Code (see https://github.com/phenomnomnominal/betterer/issues/224#issuecomment-827187113).

I couldn't get the e2e tests working or else I would have tried to add a test :(. They opened VS Code, and it say on the home screen for a while... then eventually closed with no tests actually running.

However I can confirm that with this change, and my config (see https://github.com/phenomnomnominal/betterer/pull/650#issuecomment-827197501), I'm getting betterer warnings in VS Code now:

![image](https://user-images.githubusercontent.com/342540/116163706-1b269b00-a6ad-11eb-80d3-b372520d2d57.png)