### PR TITLE
refactor(betterer 🔧): run.filePaths only defined on file tests

### DIFF
--- a/goldens/api/@betterer/betterer.d.ts
+++ b/goldens/api/@betterer/betterer.d.ts
@@ -227,7 +227,7 @@ export declare type BettererResult = {
 
 export declare type BettererRun = {
     readonly expected: BettererResult;
-    readonly filePaths: BettererFilePaths;
+    readonly filePaths: BettererFilePaths | null;
     readonly lifecycle: Promise<BettererRunSummary>;
     readonly name: string;
     readonly test: BettererTestConfig;
@@ -338,8 +338,6 @@ export declare type BettererTestOptionsComplex<DeserialisedType, SerialisedType,
     goal: DeserialisedType | BettererTestGoal<DeserialisedType>;
     deadline?: Date | string;
 };
-
-export declare function isBettererFileTestΔ(testOrConfig: unknown): testOrConfig is BettererFileTest;
 
 export declare function runner(options?: BettererOptionsRunner): Promise<BettererRunner>;
 

--- a/packages/betterer/src/context/run-summary.ts
+++ b/packages/betterer/src/context/run-summary.ts
@@ -1,23 +1,25 @@
 import assert from 'assert';
-import { BettererFilePaths } from '../fs';
+
+import { BettererDiff } from '../test';
 import { BettererResult } from '../results';
-import { BettererDiff, BettererTestConfig } from '../test';
-import { BettererRunStatus } from './run';
+import { BettererRunStatus, BettererRunΩ } from './run';
 import { BettererDelta, BettererRunSummary } from './types';
 
 export class BettererRunSummaryΩ implements BettererRunSummary {
+  public readonly lifecycle = this._runΩ.lifecycle;
+  public readonly name = this._runΩ.name;
+  public readonly filePaths = this._runΩ.filePaths;
+  public readonly expected = this._runΩ.expected;
+  public readonly timestamp = this._runΩ.timestamp;
+  public readonly test = this._runΩ.test;
+
   constructor(
-    public readonly lifecycle: Promise<BettererRunSummary>,
-    public readonly test: BettererTestConfig,
-    public readonly name: string,
-    public readonly filePaths: BettererFilePaths,
-    public readonly expected: BettererResult,
-    public readonly timestamp: number,
-    public readonly isComplete: boolean,
+    private _runΩ: BettererRunΩ,
     private _result: BettererResult | null,
     private _diff: BettererDiff | null,
     private _delta: BettererDelta | null,
-    private _status: BettererRunStatus
+    private _status: BettererRunStatus,
+    public readonly isComplete: boolean
   ) {}
 
   public get delta(): BettererDelta | null {

--- a/packages/betterer/src/context/run.ts
+++ b/packages/betterer/src/context/run.ts
@@ -1,12 +1,14 @@
+import { BettererConstraintResult } from '@betterer/constraints';
 import { BettererError } from '@betterer/errors';
 import assert from 'assert';
 
+import { BettererConfig } from '../config';
 import { BettererFilePaths } from '../fs';
 import { BettererResult } from '../results';
-import { BettererDiff, BettererTestConfig } from '../test';
+import { BettererDiff, BettererTestBase, BettererTestConfig } from '../test';
 import { Defer, defer } from '../utils';
 import { BettererRunSummaryΩ } from './run-summary';
-import { BettererRun, BettererRunStarted, BettererRunSummary } from './types';
+import { BettererRun, BettererRunning, BettererRunSummary } from './types';
 
 export enum BettererRunStatus {
   better,
@@ -20,24 +22,28 @@ export enum BettererRunStatus {
 }
 
 export class BettererRunΩ implements BettererRun {
+  public readonly isNew = this.expected.isNew;
+
   private _lifecycle: Defer<BettererRunSummary>;
   private _result: BettererResult | null = null;
   private _status: BettererRunStatus;
+  private _timestamp: number | null = null;
 
   constructor(
+    public readonly config: BettererConfig,
     public readonly name: string,
-    private readonly _test: BettererTestConfig,
+    private _test: BettererTestBase,
     public expected: BettererResult,
-    private readonly _baseline: BettererResult,
-    public filePaths: BettererFilePaths,
-    isSkipped: boolean
+    private _baseline: BettererResult,
+    public filePaths: BettererFilePaths | null
   ) {
-    this._status = isSkipped ? BettererRunStatus.skipped : BettererRunStatus.pending;
+    this._status = this._test.isSkipped ? BettererRunStatus.skipped : BettererRunStatus.pending;
     this._lifecycle = defer();
   }
 
-  public get isNew(): boolean {
-    return this.expected.isNew;
+  public get timestamp(): number {
+    assert(this._timestamp != null);
+    return this._timestamp;
   }
 
   public get isSkipped(): boolean {
@@ -49,39 +55,49 @@ export class BettererRunΩ implements BettererRun {
   }
 
   public get test(): BettererTestConfig {
-    return this._test;
+    return this._test.config;
   }
 
-  public start(): BettererRunStarted {
-    const startTime = Date.now();
+  public start(): BettererRunning {
+    this._timestamp = Date.now();
 
-    const end = async (diff: BettererDiff | null = null, isComplete = false): Promise<BettererRunSummary> => {
+    const end = async (diff: BettererDiff | null = null): Promise<BettererRunSummary> => {
       const baselineValue = this._baseline.isNew ? null : this._baseline.value;
-      const result = this._result || null;
       const resultValue = !this._result ? null : this._result.value;
 
-      const delta = await this._test.progress(baselineValue, resultValue);
-      const runSummary = new BettererRunSummaryΩ(
-        this.lifecycle,
-        this._test,
-        this.name,
-        this.filePaths,
-        this.expected,
-        startTime,
-        isComplete,
-        result,
-        diff,
-        delta,
-        this._status
-      );
+      const delta = await this.test.progress(baselineValue, resultValue);
+      const isComplete = resultValue != null && (await this.test.goal(resultValue));
+      const runSummary = new BettererRunSummaryΩ(this, this._result, diff, delta, this._status, isComplete);
       this._lifecycle.resolve(runSummary);
       return runSummary;
     };
 
     return {
-      better: async (result: BettererResult, isComplete: boolean): Promise<BettererRunSummary> => {
-        this._updateResult(BettererRunStatus.better, result);
-        return end(null, isComplete);
+      done: async (result: BettererResult): Promise<BettererRunSummary> => {
+        if (this.isNew) {
+          this._updateResult(BettererRunStatus.new, result);
+          return end(null);
+        }
+
+        const comparison = await this.test.constraint(result.value, this.expected.value);
+
+        if (comparison === BettererConstraintResult.same) {
+          this._updateResult(BettererRunStatus.same, result);
+          return end();
+        }
+
+        if (comparison === BettererConstraintResult.better) {
+          this._updateResult(BettererRunStatus.better, result);
+          return end();
+        }
+
+        if (this.config.update) {
+          this._updateResult(BettererRunStatus.update, result);
+          return end(this.test.differ(this.expected.value, result.value));
+        }
+
+        this._updateResult(BettererRunStatus.worse, result);
+        return end(this.test.differ(this.expected.value, result.value));
       },
       failed: async (error: BettererError): Promise<BettererRunSummary> => {
         assert.strictEqual(this._status, BettererRunStatus.pending);
@@ -89,24 +105,8 @@ export class BettererRunΩ implements BettererRun {
         this._lifecycle.reject(error);
         return end();
       },
-      neww: async (result: BettererResult, isComplete: boolean): Promise<BettererRunSummary> => {
-        this._updateResult(BettererRunStatus.new, result);
-        return end(null, isComplete);
-      },
-      same: async (result: BettererResult): Promise<BettererRunSummary> => {
-        this._updateResult(BettererRunStatus.same, result);
-        return end();
-      },
       skipped: async (): Promise<BettererRunSummary> => {
         return end();
-      },
-      update: async (result: BettererResult): Promise<BettererRunSummary> => {
-        this._updateResult(BettererRunStatus.update, result);
-        return end(this.test.differ(this.expected.value, result.value));
-      },
-      worse: async (result: BettererResult): Promise<BettererRunSummary> => {
-        this._updateResult(BettererRunStatus.worse, result);
-        return end(this.test.differ(this.expected.value, result.value));
       }
     };
   }

--- a/packages/betterer/src/context/types.ts
+++ b/packages/betterer/src/context/types.ts
@@ -32,7 +32,7 @@ export type BettererDelta =
 
 export type BettererRun = {
   readonly expected: BettererResult;
-  readonly filePaths: BettererFilePaths;
+  readonly filePaths: BettererFilePaths | null;
   readonly lifecycle: Promise<BettererRunSummary>;
   readonly name: string;
   readonly test: BettererTestConfig;
@@ -40,14 +40,10 @@ export type BettererRun = {
   readonly isSkipped: boolean;
 };
 
-export type BettererRunStarted = {
-  better(result: BettererResult, isComplete: boolean): Promise<BettererRunSummary>;
+export type BettererRunning = {
   failed(error: BettererError): Promise<BettererRunSummary>;
-  neww(result: BettererResult, isComplete: boolean): Promise<BettererRunSummary>;
-  same(result: BettererResult): Promise<BettererRunSummary>;
+  done(result: BettererResult): Promise<BettererRunSummary>;
   skipped(): Promise<BettererRunSummary>;
-  update(result: BettererResult): Promise<BettererRunSummary>;
-  worse(result: BettererResult): Promise<BettererRunSummary>;
 };
 
 export type BettererRunSummary = BettererRun & {

--- a/packages/betterer/src/index.ts
+++ b/packages/betterer/src/index.ts
@@ -62,6 +62,5 @@ export {
   BettererTestConfig,
   BettererTestOptions,
   BettererTestOptionsBasic,
-  BettererTestOptionsComplex,
-  isBettererFileTestΔ
+  BettererTestOptionsComplex
 } from './test/public';

--- a/packages/betterer/src/test/file-test/file-test.ts
+++ b/packages/betterer/src/test/file-test/file-test.ts
@@ -1,3 +1,4 @@
+import assert from 'assert';
 import path from 'path';
 
 import { BettererContext, BettererContextΩ, BettererRun, BettererRunΩ } from '../../context';
@@ -90,6 +91,8 @@ function createTest(
 ): BettererTestFunction<BettererFileTestResult> {
   return async (run: BettererRun, context: BettererContext): Promise<BettererFileTestResult> => {
     const runΩ = run as BettererRunΩ;
+    assert(runΩ.filePaths);
+
     resolver.setBaseDirectory(path.dirname(runΩ.test.configPath));
     const contextΩ = context as BettererContextΩ;
 

--- a/packages/betterer/src/test/index.ts
+++ b/packages/betterer/src/test/index.ts
@@ -11,7 +11,7 @@ export {
   BettererFileIssues
 } from './file-test';
 export { BettererTest } from './test';
-export { BettererTestType, isBettererFileTestΔ, isBettererTest } from './type';
+export { BettererTestType, isBettererFileTest, isBettererTest } from './type';
 export {
   BettererDeserialise,
   BettererDiff,

--- a/packages/betterer/src/test/public.ts
+++ b/packages/betterer/src/test/public.ts
@@ -11,7 +11,6 @@ export {
   BettererFileIssues
 } from './file-test/public';
 export { BettererTest } from './test';
-export { isBettererFileTestΔ } from './type';
 export {
   BettererDeserialise,
   BettererDiff,

--- a/packages/betterer/src/test/type.ts
+++ b/packages/betterer/src/test/type.ts
@@ -6,8 +6,7 @@ export enum BettererTestType {
   Unknown = 'Unknown'
 }
 
-/** @internal Definitely not stable! Please don't use! */
-export function isBettererFileTestΔ(testOrConfig: unknown): testOrConfig is BettererFileTest {
+export function isBettererFileTest(testOrConfig: unknown): testOrConfig is BettererFileTest {
   const config = (testOrConfig as BettererFileTest).config || testOrConfig;
   return config.type === BettererTestType.File;
 }

--- a/packages/reporter/src/components/runs/deltas/delta.ts
+++ b/packages/reporter/src/components/runs/deltas/delta.ts
@@ -1,9 +1,9 @@
-import { BettererRunSummary, isBettererFileTestΔ } from '@betterer/betterer';
+import { BettererRunSummary } from '@betterer/betterer';
 
 import { fileTestDelta } from './file-test-delta';
 
 export function getDelta(run: BettererRunSummary): string {
-  if (isBettererFileTestΔ(run.test)) {
+  if (run.filePaths != null) {
     return fileTestDelta(run.delta) || '';
   }
   return '';


### PR DESCRIPTION
BREAKING CHANGE: run.filePaths can be null for a global test