### PR TITLE
refactor(betterer 🔧):  update typescript and tsquery

### DIFF
--- a/goldens/api/@betterer/tsquery.d.ts
+++ b/goldens/api/@betterer/tsquery.d.ts
@@ -1,3 +1,1 @@
-export declare function tsquery(configFilePath: string, query: string): BettererFileTest;
-
-export declare function tsqueryΔ(query: string): BettererFileTest;
+export declare function tsquery(query: string): BettererFileTest;

--- a/goldens/api/@betterer/typescript.d.ts
+++ b/goldens/api/@betterer/typescript.d.ts
@@ -1,3 +1,1 @@
-export declare function typescript(configFilePath: string, extraCompilerOptions: ts.CompilerOptions): BettererFileTest;
-
-export declare function typescriptΔ(configFilePath: string, extraCompilerOptions?: ts.CompilerOptions): BettererFileTest;
+export declare function typescript(configFilePath: string, extraCompilerOptions?: ts.CompilerOptions): BettererFileTest;

--- a/packages/extension/test/test.e2e-spec.ts
+++ b/packages/extension/test/test.e2e-spec.ts
@@ -124,7 +124,7 @@ let shrinks = 2;
 export default {
   'typescript use strict mode': typescript('./tsconfig.json', {
     strict: true
-  }),
+  }).include('./src/**/*.ts'),
   'should shrink': {
     test: () => shrinks--,
     constraint: smaller

--- a/packages/tsquery/src/index.ts
+++ b/packages/tsquery/src/index.ts
@@ -1,1 +1,1 @@
-export { tsquery, tsqueryΔ } from './tsquery';
+export { tsquery } from './tsquery';

--- a/packages/tsquery/src/tsquery.ts
+++ b/packages/tsquery/src/tsquery.ts
@@ -3,40 +3,7 @@ import { BettererError } from '@betterer/errors';
 import { tsquery as tsq } from '@phenomnomnominal/tsquery';
 import { promises as fs } from 'fs';
 
-export function tsquery(configFilePath: string, query: string): BettererFileTest {
-  if (!configFilePath) {
-    throw new BettererError(
-      "for `@betterer/tsquery` to work, you need to provide the path to a tsconfig.json file, e.g. `'./tsconfig.json'`. ❌"
-    );
-  }
-  if (!query) {
-    throw new BettererError(
-      "for `@betterer/tsquery` to work, you need to provide a query, e.g. `'CallExpression > PropertyAccessExpression'`. ❌"
-    );
-  }
-
-  return new BettererFileTest(async (_, fileTestResult, resolver) => {
-    const absoluteConfigFilePath = resolver.resolve(configFilePath);
-    const projectFiles = resolver.validate(tsq.projectFiles(absoluteConfigFilePath));
-    await Promise.all(
-      projectFiles.map(async (filePath) => {
-        const fileText = await fs.readFile(filePath, 'utf8');
-        const sourceFile = tsq.ast(fileText);
-        const matches = tsq.query(sourceFile, query, { visitAllChildren: true });
-        if (matches.length === 0) {
-          return;
-        }
-        const file = fileTestResult.addFile(filePath, fileText);
-        matches.forEach((match) => {
-          file.addIssue(match.getStart(), match.getEnd(), 'TSQuery match');
-        });
-      })
-    );
-  });
-}
-
-/** @internal Definitely not stable! Please don't use! */
-export function tsqueryΔ(query: string): BettererFileTest {
+export function tsquery(query: string): BettererFileTest {
   if (!query) {
     throw new BettererError(
       "for `@betterer/tsquery` to work, you need to provide a query, e.g. `'CallExpression > PropertyAccessExpression'`. ❌"

--- a/packages/typescript/src/index.ts
+++ b/packages/typescript/src/index.ts
@@ -1,1 +1,1 @@
-export { typescript, typescriptΔ } from './typescript';
+export { typescript } from './typescript';

--- a/test/__snapshots__/betterer-tsquery.spec.ts.snap
+++ b/test/__snapshots__/betterer-tsquery.spec.ts.snap
@@ -439,31 +439,6 @@ You should try to fix the new issues! As a last resort, you can run \`betterer -
 ]
 `;
 
-exports[`betterer should throw if there is no configFilePath 1`] = `
-Array [
-  "
-   / | /     _         _   _
- '-.ooo.-'  | |__  ___| |_| |_ ___ _ __ ___ _ __
----ooooo--- | '_ // _ / __| __/ _ / '__/ _ / '__|
- .-'ooo'-.  | |_)|  __/ |_| ||  __/ | |  __/ |
-   / | /    |_.__//___|/__|/__/___|_|  /___|_|
-
-",
-  "
-   / | /     _         _   _
- '-.ooo.-'  | |__  ___| |_| |_ ___ _ __ ___ _ __
----ooooo--- | '_ // _ / __| __/ _ / '__/ _ / '__|
- .-'ooo'-.  | |_)|  __/ |_| ||  __/ | |  __/ |
-   / | /    |_.__//___|/__|/__/___|_|  /___|_|
-
-
-Error: could not read config from \\"<project>/fixtures/test-betterer-tsquery-no-config-file-path/.betterer\\". 😔
-
-Error: for \`@betterer/tsquery\` to work, you need to provide the path to a tsconfig.json file, e.g. \`'./tsconfig.json'\`. ❌
-",
-]
-`;
-
 exports[`betterer should throw if there is no query 1`] = `
 Array [
   "

--- a/test/__snapshots__/betterer-typescript.spec.ts.snap
+++ b/test/__snapshots__/betterer-typescript.spec.ts.snap
@@ -539,31 +539,6 @@ Error: for \`@betterer/typescript\` to work, you need to provide the path to a t
 ]
 `;
 
-exports[`betterer should throw if there is no extraCompilerOptions 1`] = `
-Array [
-  "
-   / | /     _         _   _
- '-.ooo.-'  | |__  ___| |_| |_ ___ _ __ ___ _ __
----ooooo--- | '_ // _ / __| __/ _ / '__/ _ / '__|
- .-'ooo'-.  | |_)|  __/ |_| ||  __/ | |  __/ |
-   / | /    |_.__//___|/__|/__/___|_|  /___|_|
-
-",
-  "
-   / | /     _         _   _
- '-.ooo.-'  | |__  ___| |_| |_ ___ _ __ ___ _ __
----ooooo--- | '_ // _ / __| __/ _ / '__/ _ / '__|
- .-'ooo'-.  | |_)|  __/ |_| ||  __/ | |  __/ |
-   / | /    |_.__//___|/__|/__/___|_|  /___|_|
-
-
-Error: could not read config from \\"<project>/fixtures/test-betterer-typescript-no-compiler-options/.betterer\\". 😔
-
-Error: for \`@betterer/typescript\` to work, you need to provide compiler options, e.g. \`{ strict: true }\`. ❌
-",
-]
-`;
-
 exports[`betterer should work with an incremental build 1`] = `
 Array [
   "

--- a/test/betterer-better.spec.ts
+++ b/test/betterer-better.spec.ts
@@ -53,9 +53,8 @@ import { tsquery } from '@betterer/tsquery';
 
 export default {
   'no raw console calls': tsquery(
-    './tsconfig.json',
     'CallExpression > PropertyAccessExpression[expression.name="console"]'
-  )
+  ).include('./src/**/*.ts')
 };  
       `,
         '.betterer.changed.ts': `
@@ -63,23 +62,9 @@ import { tsquery } from '@betterer/tsquery';
 
 export default {
   'no raw console calls': tsquery(
-    './tsconfig.json',
     'CallExpression > PropertyAccessExpression[expression.name="console"][name.name="log"]'
-  )
+  ).include('./src/**/*.ts')
 };
-              `,
-        'tsconfig.json': `
-{
-  "compilerOptions": {
-    "noEmit": true,
-    "lib": ["esnext"],
-    "moduleResolution": "node",
-    "target": "ES5",
-    "typeRoots": ["../../node_modules/@types/"],
-    "resolveJsonModule": true
-  },
-  "include": ["./src/**/*", ".betterer.ts"]
-}      
       `,
         'src/index.ts': `
 console.log('foo');

--- a/test/betterer-conflict.spec.ts
+++ b/test/betterer-conflict.spec.ts
@@ -10,9 +10,8 @@ import { tsquery } from '@betterer/tsquery';
 
 export default {
   'no raw console calls': tsquery(
-    './tsconfig.json',
     'CallExpression > PropertyAccessExpression[expression.name="console"][name.name="log"]'
-  )
+  ).include('./src/**/*.ts')
 };
               `,
       '.betterer.results': `
@@ -32,19 +31,6 @@ exports[\`no raw console calls\`] = {
   }\`
 };
       `.replace(/\|||/g, ''), // Mess with it a bit so that tooling doesn't think this is a real conflict:
-      'tsconfig.json': `
-{
-  "compilerOptions": {
-    "noEmit": true,
-    "lib": ["esnext"],
-    "moduleResolution": "node",
-    "target": "ES5",
-    "typeRoots": ["../../node_modules/@types/"],
-    "resolveJsonModule": true
-  },
-  "include": ["./src/**/*", ".betterer.ts"]
-}      
-      `,
       'src/index.ts': `
 console.log('foo');
 console.info('foo');

--- a/test/betterer-same.spec.ts
+++ b/test/betterer-same.spec.ts
@@ -58,7 +58,7 @@ import { typescript } from '@betterer/typescript';
 export default {
   'typescript use strict mode': typescript('./tsconfig.json', {
     strict: true
-  })
+  }).include('./src/**/*.ts')
 };    
       `,
         'tsconfig.json': `
@@ -121,7 +121,7 @@ import { typescript } from '@betterer/typescript';
 export default {
   'typescript use strict mode': typescript('./tsconfig.json', {
     strict: true
-  })
+  }).include('./src/**/*.ts')
 };    
       `,
         'tsconfig.json': `
@@ -183,7 +183,7 @@ import { typescript } from '@betterer/typescript';
 export default {
   'typescript use strict mode': typescript('./tsconfig.json', {
     strict: true
-  })
+  }).include('./src/**/*.ts')
 };    
       `,
         'tsconfig.json': `

--- a/test/betterer-tsquery.spec.ts
+++ b/test/betterer-tsquery.spec.ts
@@ -11,24 +11,10 @@ describe('betterer', () => {
 import { tsquery } from '@betterer/tsquery';
 
 export default {
-'tsquery no raw console.log': tsquery(
-  './tsconfig.json',
-  'CallExpression > PropertyAccessExpression[expression.name="console"][name.name="log"]'
-)
-};      
-    `,
-        'tsconfig.json': `
-{
-"compilerOptions": {
-  "noEmit": true,
-  "lib": ["esnext"],
-  "moduleResolution": "node",
-  "target": "ES5",
-  "typeRoots": ["../../node_modules/@types/"],
-  "resolveJsonModule": true
-},
-"include": ["./src/**/*", ".betterer.ts"]
-}      
+  'tsquery no raw console.log': tsquery(
+    'CallExpression > PropertyAccessExpression[expression.name="console"][name.name="log"]'
+  ).include('./src/**/*.ts')
+};
     `
       }
     );
@@ -72,34 +58,13 @@ export default {
     await cleanup();
   });
 
-  it('should throw if there is no configFilePath', async () => {
-    const { paths, logs, cleanup } = await createFixture('test-betterer-tsquery-no-config-file-path', {
-      '.betterer.js': `
-const { tsquery } = require('@betterer/tsquery');
-
-module.exports = {
-'tsquery no raw console.log': tsquery()
-};      
-    `
-    });
-
-    const configPaths = [paths.config];
-    const resultsPath = paths.results;
-
-    await expect(async () => await betterer({ configPaths, resultsPath })).rejects.toThrow();
-
-    expect(logs).toMatchSnapshot();
-
-    await cleanup();
-  });
-
   it('should throw if there is no query', async () => {
     const { paths, logs, cleanup } = await createFixture('test-betterer-tsquery-no-query', {
       '.betterer.js': `
 const { tsquery } = require('@betterer/tsquery');
 
 module.exports = {
-'tsquery no raw console.log': tsquery('./tsconfig.json')
+  'tsquery no raw console.log': tsquery()
 };
     `
     });

--- a/test/betterer-typescript-strict.spec.ts
+++ b/test/betterer-typescript-strict.spec.ts
@@ -45,7 +45,7 @@ import { typescript } from '@betterer/typescript';
 export default {
   'typescript use strict mode': typescript('./tsconfig.json', {
     strict: true
-  })
+  }).include('./src/**/*.ts')
 };
         `,
         'tsconfig.json': `

--- a/test/betterer-typescript.spec.ts
+++ b/test/betterer-typescript.spec.ts
@@ -13,7 +13,7 @@ import { typescript } from '@betterer/typescript';
 export default {
   'typescript use strict mode': typescript('./tsconfig.json', {
     strict: true
-  })
+  }).include('./src/**/*.ts')
 };
       `,
         'tsconfig.json': `
@@ -92,27 +92,6 @@ module.exports = {
     await cleanup();
   });
 
-  it('should throw if there is no extraCompilerOptions', async () => {
-    const { paths, logs, cleanup } = await createFixture('test-betterer-typescript-no-compiler-options', {
-      '.betterer.js': `
-const { typescript } = require('@betterer/typescript');
-
-module.exports = {
-  'typescript use strict mode': typescript('./tsconfig.json')
-};
-      `
-    });
-
-    const configPaths = [paths.config];
-    const resultsPath = paths.results;
-
-    await expect(async () => await betterer({ configPaths, resultsPath })).rejects.toThrow();
-
-    expect(logs).toMatchSnapshot();
-
-    await cleanup();
-  });
-
   it('should report the status of the TypeScript compiler when there is a npm dependency', async () => {
     const { paths, logs, resolve, cleanup, writeFile, runNames } = await createFixture(
       'test-betterer-typescript-dependency',
@@ -123,7 +102,7 @@ import { typescript } from '@betterer/typescript';
 export default {
   'typescript dependency': typescript('./tsconfig.json', {
     strict: true
-  })
+  }).include('./src/**/*.ts')
 };
         `,
         'tsconfig.json': `
@@ -163,10 +142,10 @@ export default {
       'test-betterer-typescript-incremental',
       {
         '.betterer.ts': `
-import { typescriptΔ } from '@betterer/typescript';
+import { typescript } from '@betterer/typescript';
 
 export default {
-  'typescript incremental': typescriptΔ('./tsconfig.json', {
+  'typescript incremental': typescript('./tsconfig.json', {
     incremental: true,
     tsBuildInfoFile: './.betterer.tsbuildinfo'
   }).include('./src/**/*.ts')

--- a/test/betterer-worse.spec.ts
+++ b/test/betterer-worse.spec.ts
@@ -53,23 +53,9 @@ import { tsquery } from '@betterer/tsquery';
 
 export default {
   'tsquery no raw console.log': tsquery(
-    './tsconfig.json',
     'CallExpression > PropertyAccessExpression[expression.name="console"][name.name="log"]'
-  )
+  ).include('./src/**/*.ts')
 };      
-      `,
-        'tsconfig.json': `
-{
-  "compilerOptions": {
-    "noEmit": true,
-    "lib": ["esnext"],
-    "moduleResolution": "node",
-    "target": "ES5",
-    "typeRoots": ["../../node_modules/@types/"],
-    "resolveJsonModule": true
-  },
-  "include": ["./src/**/*", ".betterer.ts"]
-}      
       `
       }
     );
@@ -112,23 +98,9 @@ import { tsquery } from '@betterer/tsquery';
 
 export default {
   'tsquery no raw console.log': tsquery(
-    './tsconfig.json',
     'CallExpression > PropertyAccessExpression[expression.name="console"][name.name="log"]'
-  )
+  ).include('./src/**/*.ts')
 };      
-      `,
-        'tsconfig.json': `
-{
-  "compilerOptions": {
-    "noEmit": true,
-    "lib": ["esnext"],
-    "moduleResolution": "node",
-    "target": "ES5",
-    "typeRoots": ["../../node_modules/@types/"],
-    "resolveJsonModule": true
-  },
-  "include": ["./src/**/*", ".betterer.ts"]
-}      
       `
       }
     );

--- a/test/cli/betterer-ci.spec.ts
+++ b/test/cli/betterer-ci.spec.ts
@@ -18,7 +18,7 @@ import { typescript } from '@betterer/typescript';
 export default {
   'typescript use strict mode': typescript('./tsconfig.json', {
     strict: true
-  })
+  }).include('./src/**/*.ts')
 };    
       `,
       'tsconfig.json': `
@@ -67,7 +67,7 @@ import { typescript } from '@betterer/typescript';
 export default {
   'typescript use strict mode': typescript('./tsconfig.json', {
     strict: true
-  })
+  }).include('./src/**/*.ts')
 };    
       `,
       'tsconfig.json': `
@@ -118,7 +118,7 @@ import { typescript } from '@betterer/typescript';
 export default {
   'typescript use strict mode': typescript('./tsconfig.json', {
     strict: true
-  })
+  }).include('./src/**/*.ts')
 };    
       `,
       'tsconfig.json': `

--- a/test/cli/betterer-precommit.spec.ts
+++ b/test/cli/betterer-precommit.spec.ts
@@ -20,7 +20,7 @@ import { typescript } from '@betterer/typescript';
 export default {
   'typescript use strict mode': typescript('./tsconfig.json', {
     strict: true
-  })
+  }).include('./src/**/*.ts')
 };    
       `,
       'tsconfig.json': `
@@ -79,7 +79,7 @@ import { typescript } from '@betterer/typescript';
 export default {
   'typescript use strict mode': typescript('./tsconfig.json', {
     strict: true
-  })
+  }).include('./src/**/*.ts')
 };    
       `,
       'tsconfig.json': `

--- a/test/runner/__snapshots__/betterer-runner.spec.ts.snap
+++ b/test/runner/__snapshots__/betterer-runner.spec.ts.snap
@@ -1,10 +1,10 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`betterer.runner should ignore any files outside of the scope of the tsqueryΔ tsconfig 1`] = `"// BETTERER RESULTS V2."`;
+exports[`betterer.runner should ignore any files outside of the scope of the tsquery tsconfig 1`] = `"// BETTERER RESULTS V2."`;
 
-exports[`betterer.runner should ignore any files outside of the scope of the typescriptΔ test glob 1`] = `"// BETTERER RESULTS V2."`;
+exports[`betterer.runner should ignore any files outside of the scope of the typescript test glob 1`] = `"// BETTERER RESULTS V2."`;
 
-exports[`betterer.runner should run tsqueryΔ against a file 1`] = `
+exports[`betterer.runner should run tsquery against a file 1`] = `
 "// BETTERER RESULTS V2.
 exports[\`tsquery no raw console.log\`] = {
   value: \`{
@@ -16,7 +16,7 @@ exports[\`tsquery no raw console.log\`] = {
 "
 `;
 
-exports[`betterer.runner should run typescriptΔ against a file 1`] = `
+exports[`betterer.runner should run typescript against a file 1`] = `
 "// BETTERER RESULTS V2.
 exports[\`use typescript\`] = {
   value: \`{

--- a/test/runner/betterer-runner.spec.ts
+++ b/test/runner/betterer-runner.spec.ts
@@ -177,102 +177,12 @@ module.exports = {
   });
 
   it('should run tsquery against a file', async () => {
-    const { paths, resolve, cleanup, writeFile } = await createFixture('test-betterer-tsquery-file', {
+    const { paths, resolve, cleanup, readFile, writeFile } = await createFixture('test-betterer-tsquery-file', {
       '.betterer.ts': `
 import { tsquery } from '@betterer/tsquery';
 
 export default {
   'tsquery no raw console.log': tsquery(
-    './tsconfig.json',
-    'CallExpression > PropertyAccessExpression[expression.name="console"][name.name="log"]'
-  )
-};
-      `,
-      'tsconfig.json': `
-{
-  "compilerOptions": {
-    "noEmit": true,
-    "lib": ["esnext"],
-    "moduleResolution": "node",
-    "target": "ES5",
-    "typeRoots": ["../../node_modules/@types/"],
-    "resolveJsonModule": true
-  },
-  "include": ["./src/**/*", ".betterer.ts"]
-}      
-      `
-    });
-
-    const configPaths = [paths.config];
-    const resultsPath = paths.results;
-    const { cwd } = paths;
-    const indexPath = resolve('./src/index.ts');
-
-    await writeFile(indexPath, `console.log('foo');`);
-
-    const runner = await betterer.runner({ configPaths, resultsPath, cwd });
-    await runner.queue(indexPath);
-    const summary = await runner.stop();
-    const [run] = summary.runs;
-
-    expect(run.isNew).toEqual(true);
-    expect(run.filePaths).toEqual([normalisedPath(indexPath)]);
-
-    await cleanup();
-  });
-
-  it('should ignore any files outside of the scope of the tsquery tsconfig', async () => {
-    const { paths, resolve, cleanup, writeFile } = await createFixture('test-betterer-tsquery-file-irrevelent', {
-      '.betterer.ts': `
-import { tsquery } from '@betterer/tsquery';
-
-export default {
-  'tsquery no raw console.log': tsquery(
-    './tsconfig.json',
-    'CallExpression > PropertyAccessExpression[expression.name="console"][name.name="log"]'
-  )
-};
-      `,
-      'tsconfig.json': `
-{
-  "compilerOptions": {
-    "noEmit": true,
-    "lib": ["esnext"],
-    "moduleResolution": "node",
-    "target": "ES5",
-    "typeRoots": ["../../node_modules/@types/"],
-    "resolveJsonModule": true
-  },
-  "include": ["./src/**/*", ".betterer.ts"]
-}      
-      `
-    });
-
-    const configPaths = [paths.config];
-    const resultsPath = paths.results;
-    const { cwd } = paths;
-    const testPath = resolve('./test/index.ts');
-
-    await writeFile(testPath, `console.log('foo');`);
-
-    const runner = await betterer.runner({ configPaths, resultsPath, cwd });
-    await runner.queue(testPath);
-    const summary = await runner.stop();
-    const [run] = summary.runs;
-
-    expect(run.isNew).toEqual(true);
-    expect(run.filePaths).toEqual([normalisedPath(testPath)]);
-
-    await cleanup();
-  });
-
-  it('should run tsqueryΔ against a file', async () => {
-    const { paths, resolve, cleanup, readFile, writeFile } = await createFixture('test-betterer-tsqueryd-file', {
-      '.betterer.ts': `
-import { tsqueryΔ } from '@betterer/tsquery';
-
-export default {
-  'tsquery no raw console.log': tsqueryΔ(
     'CallExpression > PropertyAccessExpression[expression.name="console"][name.name="log"]'
   ).include('./src/**/*.ts')
 };
@@ -314,15 +224,15 @@ export default {
     await cleanup();
   });
 
-  it('should ignore any files outside of the scope of the tsqueryΔ tsconfig', async () => {
+  it('should ignore any files outside of the scope of the tsquery tsconfig', async () => {
     const { paths, resolve, cleanup, readFile, writeFile } = await createFixture(
-      'test-betterer-tsqueryd-file-irrevelent',
+      'test-betterer-tsquery-file-irrevelent',
       {
         '.betterer.ts': `
-import { tsqueryΔ } from '@betterer/tsquery';
+import { tsquery } from '@betterer/tsquery';
 
 export default {
-  'tsquery no raw console.log': tsqueryΔ(
+  'tsquery no raw console.log': tsquery(
     'CallExpression > PropertyAccessExpression[expression.name="console"][name.name="log"]'
   ).include('./src/**/*.ts')
 };
@@ -366,100 +276,12 @@ export default {
   });
 
   it('should run typescript against a file', async () => {
-    const { paths, resolve, cleanup, writeFile } = await createFixture('test-betterer-typescript-file', {
+    const { paths, resolve, cleanup, readFile, writeFile } = await createFixture('test-betterer-typescript-file', {
       '.betterer.ts': `
 import { typescript } from '@betterer/typescript';
 
 export default {
-  'typescript use strict mode': typescript('./tsconfig.json', {
-    strict: true
-  })
-};
-      `,
-      'tsconfig.json': `
-{
-  "compilerOptions": {
-    "noEmit": true,
-    "lib": ["esnext"],
-    "moduleResolution": "node",
-    "target": "ES5",
-    "typeRoots": ["../../node_modules/@types/"],
-    "resolveJsonModule": true
-  },
-  "include": ["./src/**/*", ".betterer.ts"]
-}
-      `
-    });
-
-    const configPaths = [paths.config];
-    const resultsPath = paths.results;
-    const { cwd } = paths;
-    const indexPath = resolve('./src/index.ts');
-
-    await writeFile(indexPath, `const a = 'a';\nconst one = 1;\nconsole.log(a * one);`);
-
-    const runner = await betterer.runner({ configPaths, resultsPath, cwd });
-    await runner.queue(indexPath);
-    const summary = await runner.stop();
-    const [run] = summary.runs;
-
-    expect(run.isNew).toEqual(true);
-    expect(run.filePaths).toEqual([normalisedPath(indexPath)]);
-
-    await cleanup();
-  });
-
-  it('should ignore any files outside of the scope of the typescript tsconfig', async () => {
-    const { paths, resolve, cleanup, writeFile } = await createFixture('test-betterer-typescript-file-irrelevent', {
-      '.betterer.ts': `
-import { typescript } from '@betterer/typescript';
-
-export default {
-  'typescript use strict mode': typescript('./tsconfig.json', {
-    strict: true
-  })
-};
-      `,
-      'tsconfig.json': `
-{
-  "compilerOptions": {
-    "noEmit": true,
-    "lib": ["esnext"],
-    "moduleResolution": "node",
-    "target": "ES5",
-    "typeRoots": ["../../node_modules/@types/"],
-    "resolveJsonModule": true
-  },
-  "include": ["./src/**/*", ".betterer.ts"]
-}
-      `
-    });
-
-    const configPaths = [paths.config];
-    const resultsPath = paths.results;
-    const { cwd } = paths;
-    const testPath = resolve('./test/index.ts');
-
-    await writeFile(testPath, `const a = 'a';\nconst one = 1;\nconsole.log(a * one);`);
-
-    const runner = await betterer.runner({ configPaths, resultsPath, cwd });
-    await runner.queue(testPath);
-    const summary = await runner.stop();
-    const [run] = summary.runs;
-
-    expect(run.isNew).toEqual(true);
-    expect(run.filePaths).toEqual([normalisedPath(testPath)]);
-
-    await cleanup();
-  });
-
-  it('should run typescriptΔ against a file', async () => {
-    const { paths, resolve, cleanup, readFile, writeFile } = await createFixture('test-betterer-typescriptd-file', {
-      '.betterer.ts': `
-import { typescriptΔ } from '@betterer/typescript';
-
-export default {
-  'use typescript': typescriptΔ('./tsconfig.json').include('./src/**/*.ts')
+  'use typescript': typescript('./tsconfig.json').include('./src/**/*.ts')
 };
       `,
       'tsconfig.json': `
@@ -508,15 +330,15 @@ console.log(3 * 'baz');
     await cleanup();
   });
 
-  it('should ignore any files outside of the scope of the typescriptΔ test glob', async () => {
+  it('should ignore any files outside of the scope of the typescript test glob', async () => {
     const { paths, resolve, cleanup, readFile, writeFile } = await createFixture(
-      'test-betterer-typescriptd-file-irrelevent',
+      'test-betterer-typescript-file-irrelevent',
       {
         '.betterer.ts': `
-import { typescriptΔ } from '@betterer/typescript';
+import { typescript } from '@betterer/typescript';
 
 export default {
-  'use typescript': typescriptΔ('./tsconfig.json').include('./src/**/*.ts')
+  'use typescript': typescript('./tsconfig.json').include('./src/**/*.ts')
 };
       `,
         'tsconfig.json': `

--- a/test/watch/betterer-watch.spec.ts
+++ b/test/watch/betterer-watch.spec.ts
@@ -11,23 +11,9 @@ import { tsquery } from '@betterer/tsquery';
 
 export default {
   'tsquery no raw console.log': tsquery(
-    './tsconfig.json',
     'CallExpression > PropertyAccessExpression[expression.name="console"][name.name="log"]'
-  )
+  ).include('./src/**/*.ts')
 };
-      `,
-      'tsconfig.json': `
-{
-  "compilerOptions": {
-    "noEmit": true,
-    "lib": ["esnext"],
-    "moduleResolution": "node",
-    "target": "ES5",
-    "typeRoots": ["../../node_modules/@types/"],
-    "resolveJsonModule": true
-  },
-  "include": ["./src/**/*", ".betterer.ts"]
-}
       `
     });
 
@@ -93,23 +79,9 @@ import { tsquery } from '@betterer/tsquery';
 
 export default {
   'tsquery no raw console.log': tsquery(
-    './tsconfig.json',
     'CallExpression > PropertyAccessExpression[expression.name="console"][name.name="log"]'
-  )
+  ).include('./src/**/*.ts')
 };
-      `,
-      'tsconfig.json': `
-{
-  "compilerOptions": {
-    "noEmit": true,
-    "lib": ["esnext"],
-    "moduleResolution": "node",
-    "target": "ES5",
-    "typeRoots": ["../../node_modules/@types/"],
-    "resolveJsonModule": true
-  },
-  "include": ["./src/**/*", ".betterer.ts"]
-}
       `
     });
 
@@ -155,23 +127,9 @@ import { tsquery } from '@betterer/tsquery';
 
 export default {
   'tsquery no raw console.log': tsquery(
-    './tsconfig.json',
     'CallExpression > PropertyAccessExpression[expression.name="console"][name.name="log"]'
-  )
+  ).include('./src/**/*.ts')
 };
-      `,
-      'tsconfig.json': `
-{
-  "compilerOptions": {
-    "noEmit": true,
-    "lib": ["esnext"],
-    "moduleResolution": "node",
-    "target": "ES5",
-    "typeRoots": ["../../node_modules/@types/"],
-    "resolveJsonModule": true
-  },
-  "include": ["./src/**/*", ".betterer.ts"]
-}
       `,
       './src/.gitignore': `
 ignored.ts

--- a/website/docs/built-in-tests.md
+++ b/website/docs/built-in-tests.md
@@ -58,10 +58,9 @@ Use this test to incrementally remove **TSQuery** matches from your codebase. Se
 import { tsquery } from '@betterer/tsquery';
 
 export default {
-  'no raw console.log': tsquery(
-    './tsconfig.json',
+  'no raw console.log':
     'CallExpression > PropertyAccessExpression[expression.name="console"][name.name="log"]'
-  )
+  ).include('./src/**/*.ts')
 };
 ```
 
@@ -77,7 +76,7 @@ import { typescript } from '@betterer/typescript';
 export default {
   'stricter compilation': typescript('./tsconfig.json', {
     strict: true
-  })
+  }).include('./src/**/*.ts')
 };
 ```
 


### PR DESCRIPTION
BREAKING CHANGE: tsquery no longer requires tsconfig