### PR TITLE
Fix error when using worktrees or submodules

### DIFF
--- a/packages/betterer/package.json
+++ b/packages/betterer/package.json
@@ -37,7 +37,6 @@
     "chokidar": "^3.3.1",
     "djb2a": "^1.2.0",
     "fast-memoize": "^2.5.2",
-    "find-git-root": "^1.0.4",
     "lines-and-columns": "^1.1.6",
     "minimatch": "^3.0.4",
     "prettier": "^2.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4434,11 +4434,6 @@ fill-range@^7.0.1:
   dependencies:
     to-regex-range "^5.0.1"
 
-find-git-root@^1.0.4:
-  version "1.0.4"
-  resolved "https://registry.npmjs.org/find-git-root/-/find-git-root-1.0.4.tgz#8bc1e0897db783e06762bf050b0943288e5399fd"
-  integrity sha512-468fmirKKgcrqfZfPn0xIpwZUUsZQcYXfx0RC2/jX39GPz83TwutQNZZhDrI6HqjO8cRejxQVaUY8GQdXopFfA==
-
 find-node-modules@2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/find-node-modules/-/find-node-modules-2.0.0.tgz#5db1fb9e668a3d451db3d618cd167cdd59e41b69"


### PR DESCRIPTION
Pass parent `.git` directory to `simple-git` when the git directory is resolved to `.git/worktrees/etc` or `.git/modules/etc`.

Honestly since worktrees are local only things... I think a unit test would be difficult. It'd probably have to set up a worktree, put code into it, and test betterer there? I just made a test repo and verified the change works. If you have other ideas for tests, let me know.

Fixes #786