### PR TITLE
Fix results reordering if ran on a single file

### DIFF
--- a/packages/betterer/src/test/file-test/file-test-result.ts
+++ b/packages/betterer/src/test/file-test/file-test-result.ts
@@ -31,8 +31,9 @@ export class BettererFileTestResultΩ implements BettererFileTestResult {
     return file;
   }
 
-  public addFile(absolutePath: string, fileText: string): BettererFile {
+  public addFile(filePath: string, fileText: string): BettererFile {
     assert(this._resolver);
+    const absolutePath = this._resolver.resolve(filePath);
     const file = new BettererFileΩ(absolutePath, fileText);
     const existingFile = this._fileMap[file.absolutePath];
     if (existingFile) {

--- a/packages/betterer/src/test/file-test/serialiser.ts
+++ b/packages/betterer/src/test/file-test/serialiser.ts
@@ -11,6 +11,7 @@ export function deserialise(serialised: BettererFileIssuesMapSerialised, results
       return { line, column, length, message, hash };
     });
     const absolutePath = getAbsolutePath(resultsPath, relativePath);
+    key = `${absolutePath}:${fileHash}`;
     deserialised.addExpected({ absolutePath, key, hash: fileHash, issues });
   });
   return deserialised;

--- a/test/__snapshots__/betterer-file-test.spec.ts.snap
+++ b/test/__snapshots__/betterer-file-test.spec.ts.snap
@@ -593,3 +593,604 @@ You should try to fix the new issues! As a last resort, you can run \`betterer -
 ",
 ]
 `;
+
+exports[`betterer should sort files by their file path 1`] = `
+"// BETTERER RESULTS V2.
+exports[\`file test custom goal\`] = {
+  value: \`{
+    \\"src/a.ts:2053668783\\": [
+      [0, 0, 9, \\"Unexpected \\\\'debugger\\\\' statement.\\", \\"3201740415\\"],
+      [1, 0, 9, \\"Unexpected \\\\'debugger\\\\' statement.\\", \\"3201740415\\"]
+    ],
+    \\"src/b.ts:2053668783\\": [
+      [0, 0, 9, \\"Unexpected \\\\'debugger\\\\' statement.\\", \\"3201740415\\"],
+      [1, 0, 9, \\"Unexpected \\\\'debugger\\\\' statement.\\", \\"3201740415\\"]
+    ],
+    \\"src/c.ts:2053668783\\": [
+      [0, 0, 9, \\"Unexpected \\\\'debugger\\\\' statement.\\", \\"3201740415\\"],
+      [1, 0, 9, \\"Unexpected \\\\'debugger\\\\' statement.\\", \\"3201740415\\"]
+    ],
+    \\"src/d.ts:2053668783\\": [
+      [0, 0, 9, \\"Unexpected \\\\'debugger\\\\' statement.\\", \\"3201740415\\"],
+      [1, 0, 9, \\"Unexpected \\\\'debugger\\\\' statement.\\", \\"3201740415\\"]
+    ]
+  }\`
+};
+"
+`;
+
+exports[`betterer should sort files by their file path 2`] = `
+Array [
+  "
+   / | /     _         _   _
+ '-.ooo.-'  | |__  ___| |_| |_ ___ _ __ ___ _ __
+---ooooo--- | '_ // _ / __| __/ _ / '__/ _ / '__|
+ .-'ooo'-.  | |_)|  __/ |_| ||  __/ | |  __/ |
+   / | /    |_.__//___|/__|/__/___|_|  /___|_|
+
+",
+  "
+   / | /     _         _   _
+ '-.ooo.-'  | |__  ___| |_| |_ ___ _ __ ___ _ __
+---ooooo--- | '_ // _ / __| __/ _ / '__/ _ / '__|
+ .-'ooo'-.  | |_)|  __/ |_| ||  __/ | |  __/ |
+   / | /    |_.__//___|/__|/__/___|_|  /___|_|
+
+🌟 Betterer (0ms):
+
+",
+  "
+   / | /     _         _   _
+ '-.ooo.-'  | |__  ___| |_| |_ ___ _ __ ___ _ __
+---ooooo--- | '_ // _ / __| __/ _ / '__/ _ / '__|
+ .-'ooo'-.  | |_)|  __/ |_| ||  __/ | |  __/ |
+   / | /    |_.__//___|/__|/__/___|_|  /___|_|
+
+🌟 Betterer (0ms): 1 test running...
+🤔 file test custom goal: running \\"file test custom goal\\"!
+
+",
+  "
+   / | /     _         _   _
+ '-.ooo.-'  | |__  ___| |_| |_ ___ _ __ ___ _ __
+---ooooo--- | '_ // _ / __| __/ _ / '__/ _ / '__|
+ .-'ooo'-.  | |_)|  __/ |_| ||  __/ | |  __/ |
+   / | /    |_.__//___|/__|/__/___|_|  /___|_|
+
+🌟 Betterer (0ms): 1 test running...
+✅ file test custom goal: \\"file test custom goal\\" got checked for the first time! (8 issues) 🎉
+
+",
+  "
+   / | /     _         _   _
+ '-.ooo.-'  | |__  ___| |_| |_ ___ _ __ ___ _ __
+---ooooo--- | '_ // _ / __| __/ _ / '__/ _ / '__|
+ .-'ooo'-.  | |_)|  __/ |_| ||  __/ | |  __/ |
+   / | /    |_.__//___|/__|/__/___|_|  /___|_|
+
+🎉 Betterer (0ms): 1 test done!
+✅ file test custom goal: \\"file test custom goal\\" got checked for the first time! (8 issues) 🎉
+
+",
+  "
+   / | /     _         _   _
+ '-.ooo.-'  | |__  ___| |_| |_ ___ _ __ ___ _ __
+---ooooo--- | '_ // _ / __| __/ _ / '__/ _ / '__|
+ .-'ooo'-.  | |_)|  __/ |_| ||  __/ | |  __/ |
+   / | /    |_.__//___|/__|/__/___|_|  /___|_|
+
+🎉 Betterer (0ms): 1 test done!
+✅ file test custom goal: \\"file test custom goal\\" got checked for the first time! (8 issues) 🎉
+
+1 test got checked. 🤔
+1 test got checked for the first time! 🎉
+
+",
+]
+`;
+
+exports[`betterer should sort files by their file path correctly with absolute paths 1`] = `
+"// BETTERER RESULTS V2.
+exports[\`file test custom goal\`] = {
+  value: \`{
+    \\"src/a.ts:2053668783\\": [
+      [0, 0, 9, \\"Unexpected \\\\'debugger\\\\' statement.\\", \\"3201740415\\"],
+      [1, 0, 9, \\"Unexpected \\\\'debugger\\\\' statement.\\", \\"3201740415\\"]
+    ],
+    \\"src/b.ts:2053668783\\": [
+      [0, 0, 9, \\"Unexpected \\\\'debugger\\\\' statement.\\", \\"3201740415\\"],
+      [1, 0, 9, \\"Unexpected \\\\'debugger\\\\' statement.\\", \\"3201740415\\"]
+    ],
+    \\"src/c.ts:1761844991\\": [
+      [0, 0, 9, \\"Unexpected \\\\'debugger\\\\' statement.\\", \\"3201740415\\"],
+      [1, 0, 9, \\"Unexpected \\\\'debugger\\\\' statement.\\", \\"3201740415\\"],
+      [2, 0, 9, \\"Unexpected \\\\'debugger\\\\' statement.\\", \\"3201740415\\"]
+    ],
+    \\"src/d.ts:2053668783\\": [
+      [0, 0, 9, \\"Unexpected \\\\'debugger\\\\' statement.\\", \\"3201740415\\"],
+      [1, 0, 9, \\"Unexpected \\\\'debugger\\\\' statement.\\", \\"3201740415\\"]
+    ]
+  }\`
+};
+"
+`;
+
+exports[`betterer should sort files by their file path correctly with absolute paths 2`] = `
+Array [
+  "
+   / | /     _         _   _
+ '-.ooo.-'  | |__  ___| |_| |_ ___ _ __ ___ _ __
+---ooooo--- | '_ // _ / __| __/ _ / '__/ _ / '__|
+ .-'ooo'-.  | |_)|  __/ |_| ||  __/ | |  __/ |
+   / | /    |_.__//___|/__|/__/___|_|  /___|_|
+
+",
+  "
+   / | /     _         _   _
+ '-.ooo.-'  | |__  ___| |_| |_ ___ _ __ ___ _ __
+---ooooo--- | '_ // _ / __| __/ _ / '__/ _ / '__|
+ .-'ooo'-.  | |_)|  __/ |_| ||  __/ | |  __/ |
+   / | /    |_.__//___|/__|/__/___|_|  /___|_|
+
+🌟 Betterer (0ms):
+
+",
+  "
+   / | /     _         _   _
+ '-.ooo.-'  | |__  ___| |_| |_ ___ _ __ ___ _ __
+---ooooo--- | '_ // _ / __| __/ _ / '__/ _ / '__|
+ .-'ooo'-.  | |_)|  __/ |_| ||  __/ | |  __/ |
+   / | /    |_.__//___|/__|/__/___|_|  /___|_|
+
+🌟 Betterer (0ms): 1 test running...
+🤔 file test custom goal: running \\"file test custom goal\\"!
+
+",
+  "
+   / | /     _         _   _
+ '-.ooo.-'  | |__  ___| |_| |_ ___ _ __ ___ _ __
+---ooooo--- | '_ // _ / __| __/ _ / '__/ _ / '__|
+ .-'ooo'-.  | |_)|  __/ |_| ||  __/ | |  __/ |
+   / | /    |_.__//___|/__|/__/___|_|  /___|_|
+
+🌟 Betterer (0ms): 1 test running...
+✅ file test custom goal: \\"file test custom goal\\" got checked for the first time! (8 issues) 🎉
+
+",
+  "
+   / | /     _         _   _
+ '-.ooo.-'  | |__  ___| |_| |_ ___ _ __ ___ _ __
+---ooooo--- | '_ // _ / __| __/ _ / '__/ _ / '__|
+ .-'ooo'-.  | |_)|  __/ |_| ||  __/ | |  __/ |
+   / | /    |_.__//___|/__|/__/___|_|  /___|_|
+
+🎉 Betterer (0ms): 1 test done!
+✅ file test custom goal: \\"file test custom goal\\" got checked for the first time! (8 issues) 🎉
+
+",
+  "
+   / | /     _         _   _
+ '-.ooo.-'  | |__  ___| |_| |_ ___ _ __ ___ _ __
+---ooooo--- | '_ // _ / __| __/ _ / '__/ _ / '__|
+ .-'ooo'-.  | |_)|  __/ |_| ||  __/ | |  __/ |
+   / | /    |_.__//___|/__|/__/___|_|  /___|_|
+
+🎉 Betterer (0ms): 1 test done!
+✅ file test custom goal: \\"file test custom goal\\" got checked for the first time! (8 issues) 🎉
+
+1 test got checked. 🤔
+1 test got checked for the first time! 🎉
+
+",
+  "
+   / | /     _         _   _
+ '-.ooo.-'  | |__  ___| |_| |_ ___ _ __ ___ _ __
+---ooooo--- | '_ // _ / __| __/ _ / '__/ _ / '__|
+ .-'ooo'-.  | |_)|  __/ |_| ||  __/ | |  __/ |
+   / | /    |_.__//___|/__|/__/___|_|  /___|_|
+
+",
+  "
+   / | /     _         _   _
+ '-.ooo.-'  | |__  ___| |_| |_ ___ _ __ ___ _ __
+---ooooo--- | '_ // _ / __| __/ _ / '__/ _ / '__|
+ .-'ooo'-.  | |_)|  __/ |_| ||  __/ | |  __/ |
+   / | /    |_.__//___|/__|/__/___|_|  /___|_|
+
+🌟 Betterer (0ms):
+
+",
+  "
+   / | /     _         _   _
+ '-.ooo.-'  | |__  ___| |_| |_ ___ _ __ ___ _ __
+---ooooo--- | '_ // _ / __| __/ _ / '__/ _ / '__|
+ .-'ooo'-.  | |_)|  __/ |_| ||  __/ | |  __/ |
+   / | /    |_.__//___|/__|/__/___|_|  /___|_|
+
+🌟 Betterer (0ms): 1 test running...
+🤔 file test custom goal: running \\"file test custom goal\\"!
+
+",
+  "
+   / | /     _         _   _
+ '-.ooo.-'  | |__  ___| |_| |_ ___ _ __ ___ _ __
+---ooooo--- | '_ // _ / __| __/ _ / '__/ _ / '__|
+ .-'ooo'-.  | |_)|  __/ |_| ||  __/ | |  __/ |
+   / | /    |_.__//___|/__|/__/___|_|  /___|_|
+
+🌟 Betterer (0ms): 1 test running...
+・ 2 existing issues in \\"<project>/fixtures/test-betterer-file-test-sort-single-file-absolute/src/c.ts\\".
+🤔 file test custom goal: running \\"file test custom goal\\"!
+
+",
+  "
+   / | /     _         _   _
+ '-.ooo.-'  | |__  ___| |_| |_ ___ _ __ ___ _ __
+---ooooo--- | '_ // _ / __| __/ _ / '__/ _ / '__|
+ .-'ooo'-.  | |_)|  __/ |_| ||  __/ | |  __/ |
+   / | /    |_.__//___|/__|/__/___|_|  /___|_|
+
+🌟 Betterer (0ms): 1 test running...
+・ 2 existing issues in \\"<project>/fixtures/test-betterer-file-test-sort-single-file-absolute/src/c.ts\\".
+・ 1 new issue in \\"<project>/fixtures/test-betterer-file-test-sort-single-file-absolute/src/c.ts\\":
+🤔 file test custom goal: running \\"file test custom goal\\"!
+
+",
+  "
+   / | /     _         _   _
+ '-.ooo.-'  | |__  ___| |_| |_ ___ _ __ ___ _ __
+---ooooo--- | '_ // _ / __| __/ _ / '__/ _ / '__|
+ .-'ooo'-.  | |_)|  __/ |_| ||  __/ | |  __/ |
+   / | /    |_.__//___|/__|/__/___|_|  /___|_|
+
+🌟 Betterer (0ms): 1 test running...
+・ 2 existing issues in \\"<project>/fixtures/test-betterer-file-test-sort-single-file-absolute/src/c.ts\\".
+・ 1 new issue in \\"<project>/fixtures/test-betterer-file-test-sort-single-file-absolute/src/c.ts\\":
+・
+・   <project>/fixtures/test-betterer-file-test-sort-single-file-absolute/src/c.ts
+・   1 | debugger;
+・   2 | debugger;
+・ > 3 | debugger;
+・     | ^^^^^^^^^ Unexpected 'debugger' statement.
+・
+🤔 file test custom goal: running \\"file test custom goal\\"!
+
+",
+  "
+   / | /     _         _   _
+ '-.ooo.-'  | |__  ___| |_| |_ ___ _ __ ___ _ __
+---ooooo--- | '_ // _ / __| __/ _ / '__/ _ / '__|
+ .-'ooo'-.  | |_)|  __/ |_| ||  __/ | |  __/ |
+   / | /    |_.__//___|/__|/__/___|_|  /___|_|
+
+🌟 Betterer (0ms): 1 test running...
+・ 2 existing issues in \\"<project>/fixtures/test-betterer-file-test-sort-single-file-absolute/src/c.ts\\".
+・ 1 new issue in \\"<project>/fixtures/test-betterer-file-test-sort-single-file-absolute/src/c.ts\\":
+・
+・   <project>/fixtures/test-betterer-file-test-sort-single-file-absolute/src/c.ts
+・   1 | debugger;
+・   2 | debugger;
+・ > 3 | debugger;
+・     | ^^^^^^^^^ Unexpected 'debugger' statement.
+・
+✅ file test custom goal: \\"file test custom goal\\" got force updated. (1 new issue, 9 total) 🆙
+
+",
+  "
+   / | /     _         _   _
+ '-.ooo.-'  | |__  ___| |_| |_ ___ _ __ ___ _ __
+---ooooo--- | '_ // _ / __| __/ _ / '__/ _ / '__|
+ .-'ooo'-.  | |_)|  __/ |_| ||  __/ | |  __/ |
+   / | /    |_.__//___|/__|/__/___|_|  /___|_|
+
+🌟 Betterer (0ms): 1 test running...
+✅ file test custom goal: \\"file test custom goal\\" got force updated. (1 new issue, 9 total) 🆙
+・ 2 existing issues in \\"<project>/fixtures/test-betterer-file-test-sort-single-file-absolute/src/c.ts\\".
+・ 1 new issue in \\"<project>/fixtures/test-betterer-file-test-sort-single-file-absolute/src/c.ts\\":
+・
+・   <project>/fixtures/test-betterer-file-test-sort-single-file-absolute/src/c.ts
+・   1 | debugger;
+・   2 | debugger;
+・ > 3 | debugger;
+・     | ^^^^^^^^^ Unexpected 'debugger' statement.
+・
+
+",
+  "
+   / | /     _         _   _
+ '-.ooo.-'  | |__  ___| |_| |_ ___ _ __ ___ _ __
+---ooooo--- | '_ // _ / __| __/ _ / '__/ _ / '__|
+ .-'ooo'-.  | |_)|  __/ |_| ||  __/ | |  __/ |
+   / | /    |_.__//___|/__|/__/___|_|  /___|_|
+
+🎉 Betterer (0ms): 1 test done!
+✅ file test custom goal: \\"file test custom goal\\" got force updated. (1 new issue, 9 total) 🆙
+・ 2 existing issues in \\"<project>/fixtures/test-betterer-file-test-sort-single-file-absolute/src/c.ts\\".
+・ 1 new issue in \\"<project>/fixtures/test-betterer-file-test-sort-single-file-absolute/src/c.ts\\":
+・
+・   <project>/fixtures/test-betterer-file-test-sort-single-file-absolute/src/c.ts
+・   1 | debugger;
+・   2 | debugger;
+・ > 3 | debugger;
+・     | ^^^^^^^^^ Unexpected 'debugger' statement.
+・
+
+",
+  "
+   / | /     _         _   _
+ '-.ooo.-'  | |__  ___| |_| |_ ___ _ __ ___ _ __
+---ooooo--- | '_ // _ / __| __/ _ / '__/ _ / '__|
+ .-'ooo'-.  | |_)|  __/ |_| ||  __/ | |  __/ |
+   / | /    |_.__//___|/__|/__/___|_|  /___|_|
+
+🎉 Betterer (0ms): 1 test done!
+✅ file test custom goal: \\"file test custom goal\\" got force updated. (1 new issue, 9 total) 🆙
+・ 2 existing issues in \\"<project>/fixtures/test-betterer-file-test-sort-single-file-absolute/src/c.ts\\".
+・ 1 new issue in \\"<project>/fixtures/test-betterer-file-test-sort-single-file-absolute/src/c.ts\\":
+・
+・   <project>/fixtures/test-betterer-file-test-sort-single-file-absolute/src/c.ts
+・   1 | debugger;
+・   2 | debugger;
+・ > 3 | debugger;
+・     | ^^^^^^^^^ Unexpected 'debugger' statement.
+・
+
+1 test got checked. 🤔
+1 test got force updated. 🆙
+
+",
+]
+`;
+
+exports[`betterer should sort files by their file path even when only running on a single file 1`] = `
+"// BETTERER RESULTS V2.
+exports[\`file test custom goal\`] = {
+  value: \`{
+    \\"src/a.ts:2053668783\\": [
+      [0, 0, 9, \\"Unexpected \\\\'debugger\\\\' statement.\\", \\"3201740415\\"],
+      [1, 0, 9, \\"Unexpected \\\\'debugger\\\\' statement.\\", \\"3201740415\\"]
+    ],
+    \\"src/b.ts:2053668783\\": [
+      [0, 0, 9, \\"Unexpected \\\\'debugger\\\\' statement.\\", \\"3201740415\\"],
+      [1, 0, 9, \\"Unexpected \\\\'debugger\\\\' statement.\\", \\"3201740415\\"]
+    ],
+    \\"src/c.ts:1761844991\\": [
+      [0, 0, 9, \\"Unexpected \\\\'debugger\\\\' statement.\\", \\"3201740415\\"],
+      [1, 0, 9, \\"Unexpected \\\\'debugger\\\\' statement.\\", \\"3201740415\\"],
+      [2, 0, 9, \\"Unexpected \\\\'debugger\\\\' statement.\\", \\"3201740415\\"]
+    ],
+    \\"src/d.ts:2053668783\\": [
+      [0, 0, 9, \\"Unexpected \\\\'debugger\\\\' statement.\\", \\"3201740415\\"],
+      [1, 0, 9, \\"Unexpected \\\\'debugger\\\\' statement.\\", \\"3201740415\\"]
+    ]
+  }\`
+};
+"
+`;
+
+exports[`betterer should sort files by their file path even when only running on a single file 2`] = `
+Array [
+  "
+   / | /     _         _   _
+ '-.ooo.-'  | |__  ___| |_| |_ ___ _ __ ___ _ __
+---ooooo--- | '_ // _ / __| __/ _ / '__/ _ / '__|
+ .-'ooo'-.  | |_)|  __/ |_| ||  __/ | |  __/ |
+   / | /    |_.__//___|/__|/__/___|_|  /___|_|
+
+",
+  "
+   / | /     _         _   _
+ '-.ooo.-'  | |__  ___| |_| |_ ___ _ __ ___ _ __
+---ooooo--- | '_ // _ / __| __/ _ / '__/ _ / '__|
+ .-'ooo'-.  | |_)|  __/ |_| ||  __/ | |  __/ |
+   / | /    |_.__//___|/__|/__/___|_|  /___|_|
+
+🌟 Betterer (0ms):
+
+",
+  "
+   / | /     _         _   _
+ '-.ooo.-'  | |__  ___| |_| |_ ___ _ __ ___ _ __
+---ooooo--- | '_ // _ / __| __/ _ / '__/ _ / '__|
+ .-'ooo'-.  | |_)|  __/ |_| ||  __/ | |  __/ |
+   / | /    |_.__//___|/__|/__/___|_|  /___|_|
+
+🌟 Betterer (0ms): 1 test running...
+🤔 file test custom goal: running \\"file test custom goal\\"!
+
+",
+  "
+   / | /     _         _   _
+ '-.ooo.-'  | |__  ___| |_| |_ ___ _ __ ___ _ __
+---ooooo--- | '_ // _ / __| __/ _ / '__/ _ / '__|
+ .-'ooo'-.  | |_)|  __/ |_| ||  __/ | |  __/ |
+   / | /    |_.__//___|/__|/__/___|_|  /___|_|
+
+🌟 Betterer (0ms): 1 test running...
+✅ file test custom goal: \\"file test custom goal\\" got checked for the first time! (8 issues) 🎉
+
+",
+  "
+   / | /     _         _   _
+ '-.ooo.-'  | |__  ___| |_| |_ ___ _ __ ___ _ __
+---ooooo--- | '_ // _ / __| __/ _ / '__/ _ / '__|
+ .-'ooo'-.  | |_)|  __/ |_| ||  __/ | |  __/ |
+   / | /    |_.__//___|/__|/__/___|_|  /___|_|
+
+🎉 Betterer (0ms): 1 test done!
+✅ file test custom goal: \\"file test custom goal\\" got checked for the first time! (8 issues) 🎉
+
+",
+  "
+   / | /     _         _   _
+ '-.ooo.-'  | |__  ___| |_| |_ ___ _ __ ___ _ __
+---ooooo--- | '_ // _ / __| __/ _ / '__/ _ / '__|
+ .-'ooo'-.  | |_)|  __/ |_| ||  __/ | |  __/ |
+   / | /    |_.__//___|/__|/__/___|_|  /___|_|
+
+🎉 Betterer (0ms): 1 test done!
+✅ file test custom goal: \\"file test custom goal\\" got checked for the first time! (8 issues) 🎉
+
+1 test got checked. 🤔
+1 test got checked for the first time! 🎉
+
+",
+  "
+   / | /     _         _   _
+ '-.ooo.-'  | |__  ___| |_| |_ ___ _ __ ___ _ __
+---ooooo--- | '_ // _ / __| __/ _ / '__/ _ / '__|
+ .-'ooo'-.  | |_)|  __/ |_| ||  __/ | |  __/ |
+   / | /    |_.__//___|/__|/__/___|_|  /___|_|
+
+",
+  "
+   / | /     _         _   _
+ '-.ooo.-'  | |__  ___| |_| |_ ___ _ __ ___ _ __
+---ooooo--- | '_ // _ / __| __/ _ / '__/ _ / '__|
+ .-'ooo'-.  | |_)|  __/ |_| ||  __/ | |  __/ |
+   / | /    |_.__//___|/__|/__/___|_|  /___|_|
+
+🌟 Betterer (0ms):
+
+",
+  "
+   / | /     _         _   _
+ '-.ooo.-'  | |__  ___| |_| |_ ___ _ __ ___ _ __
+---ooooo--- | '_ // _ / __| __/ _ / '__/ _ / '__|
+ .-'ooo'-.  | |_)|  __/ |_| ||  __/ | |  __/ |
+   / | /    |_.__//___|/__|/__/___|_|  /___|_|
+
+🌟 Betterer (0ms): 1 test running...
+🤔 file test custom goal: running \\"file test custom goal\\"!
+
+",
+  "
+   / | /     _         _   _
+ '-.ooo.-'  | |__  ___| |_| |_ ___ _ __ ___ _ __
+---ooooo--- | '_ // _ / __| __/ _ / '__/ _ / '__|
+ .-'ooo'-.  | |_)|  __/ |_| ||  __/ | |  __/ |
+   / | /    |_.__//___|/__|/__/___|_|  /___|_|
+
+🌟 Betterer (0ms): 1 test running...
+・ 2 existing issues in \\"<project>/fixtures/test-betterer-file-test-sort-single-file/src/c.ts\\".
+🤔 file test custom goal: running \\"file test custom goal\\"!
+
+",
+  "
+   / | /     _         _   _
+ '-.ooo.-'  | |__  ___| |_| |_ ___ _ __ ___ _ __
+---ooooo--- | '_ // _ / __| __/ _ / '__/ _ / '__|
+ .-'ooo'-.  | |_)|  __/ |_| ||  __/ | |  __/ |
+   / | /    |_.__//___|/__|/__/___|_|  /___|_|
+
+🌟 Betterer (0ms): 1 test running...
+・ 2 existing issues in \\"<project>/fixtures/test-betterer-file-test-sort-single-file/src/c.ts\\".
+・ 1 new issue in \\"<project>/fixtures/test-betterer-file-test-sort-single-file/src/c.ts\\":
+🤔 file test custom goal: running \\"file test custom goal\\"!
+
+",
+  "
+   / | /     _         _   _
+ '-.ooo.-'  | |__  ___| |_| |_ ___ _ __ ___ _ __
+---ooooo--- | '_ // _ / __| __/ _ / '__/ _ / '__|
+ .-'ooo'-.  | |_)|  __/ |_| ||  __/ | |  __/ |
+   / | /    |_.__//___|/__|/__/___|_|  /___|_|
+
+🌟 Betterer (0ms): 1 test running...
+・ 2 existing issues in \\"<project>/fixtures/test-betterer-file-test-sort-single-file/src/c.ts\\".
+・ 1 new issue in \\"<project>/fixtures/test-betterer-file-test-sort-single-file/src/c.ts\\":
+・
+・   <project>/fixtures/test-betterer-file-test-sort-single-file/src/c.ts
+・   1 | debugger;
+・   2 | debugger;
+・ > 3 | debugger;
+・     | ^^^^^^^^^ Unexpected 'debugger' statement.
+・
+🤔 file test custom goal: running \\"file test custom goal\\"!
+
+",
+  "
+   / | /     _         _   _
+ '-.ooo.-'  | |__  ___| |_| |_ ___ _ __ ___ _ __
+---ooooo--- | '_ // _ / __| __/ _ / '__/ _ / '__|
+ .-'ooo'-.  | |_)|  __/ |_| ||  __/ | |  __/ |
+   / | /    |_.__//___|/__|/__/___|_|  /___|_|
+
+🌟 Betterer (0ms): 1 test running...
+・ 2 existing issues in \\"<project>/fixtures/test-betterer-file-test-sort-single-file/src/c.ts\\".
+・ 1 new issue in \\"<project>/fixtures/test-betterer-file-test-sort-single-file/src/c.ts\\":
+・
+・   <project>/fixtures/test-betterer-file-test-sort-single-file/src/c.ts
+・   1 | debugger;
+・   2 | debugger;
+・ > 3 | debugger;
+・     | ^^^^^^^^^ Unexpected 'debugger' statement.
+・
+✅ file test custom goal: \\"file test custom goal\\" got force updated. (1 new issue, 9 total) 🆙
+
+",
+  "
+   / | /     _         _   _
+ '-.ooo.-'  | |__  ___| |_| |_ ___ _ __ ___ _ __
+---ooooo--- | '_ // _ / __| __/ _ / '__/ _ / '__|
+ .-'ooo'-.  | |_)|  __/ |_| ||  __/ | |  __/ |
+   / | /    |_.__//___|/__|/__/___|_|  /___|_|
+
+🌟 Betterer (0ms): 1 test running...
+✅ file test custom goal: \\"file test custom goal\\" got force updated. (1 new issue, 9 total) 🆙
+・ 2 existing issues in \\"<project>/fixtures/test-betterer-file-test-sort-single-file/src/c.ts\\".
+・ 1 new issue in \\"<project>/fixtures/test-betterer-file-test-sort-single-file/src/c.ts\\":
+・
+・   <project>/fixtures/test-betterer-file-test-sort-single-file/src/c.ts
+・   1 | debugger;
+・   2 | debugger;
+・ > 3 | debugger;
+・     | ^^^^^^^^^ Unexpected 'debugger' statement.
+・
+
+",
+  "
+   / | /     _         _   _
+ '-.ooo.-'  | |__  ___| |_| |_ ___ _ __ ___ _ __
+---ooooo--- | '_ // _ / __| __/ _ / '__/ _ / '__|
+ .-'ooo'-.  | |_)|  __/ |_| ||  __/ | |  __/ |
+   / | /    |_.__//___|/__|/__/___|_|  /___|_|
+
+🎉 Betterer (0ms): 1 test done!
+✅ file test custom goal: \\"file test custom goal\\" got force updated. (1 new issue, 9 total) 🆙
+・ 2 existing issues in \\"<project>/fixtures/test-betterer-file-test-sort-single-file/src/c.ts\\".
+・ 1 new issue in \\"<project>/fixtures/test-betterer-file-test-sort-single-file/src/c.ts\\":
+・
+・   <project>/fixtures/test-betterer-file-test-sort-single-file/src/c.ts
+・   1 | debugger;
+・   2 | debugger;
+・ > 3 | debugger;
+・     | ^^^^^^^^^ Unexpected 'debugger' statement.
+・
+
+",
+  "
+   / | /     _         _   _
+ '-.ooo.-'  | |__  ___| |_| |_ ___ _ __ ___ _ __
+---ooooo--- | '_ // _ / __| __/ _ / '__/ _ / '__|
+ .-'ooo'-.  | |_)|  __/ |_| ||  __/ | |  __/ |
+   / | /    |_.__//___|/__|/__/___|_|  /___|_|
+
+🎉 Betterer (0ms): 1 test done!
+✅ file test custom goal: \\"file test custom goal\\" got force updated. (1 new issue, 9 total) 🆙
+・ 2 existing issues in \\"<project>/fixtures/test-betterer-file-test-sort-single-file/src/c.ts\\".
+・ 1 new issue in \\"<project>/fixtures/test-betterer-file-test-sort-single-file/src/c.ts\\":
+・
+・   <project>/fixtures/test-betterer-file-test-sort-single-file/src/c.ts
+・   1 | debugger;
+・   2 | debugger;
+・ > 3 | debugger;
+・     | ^^^^^^^^^ Unexpected 'debugger' statement.
+・
+
+1 test got checked. 🤔
+1 test got force updated. 🆙
+
+",
+]
+`;


### PR DESCRIPTION
Since sorting is now handled upstream in `file-test`, the `sort` in the printer causes absolute paths mixed in with relative paths to sort incorrectly. We know the results are sorted correctly already, so we can just remove the sort and call it good.

This could potentially mean that non-file-test results get reordered arbitrarily... but all tests pass, so looks like there weren't checks for that.

Also added `fixtures` to jest ignores to prevent infinite watch loop when running jest in watch mode.