### PR TITLE
Better diff logging

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -12,5 +12,6 @@ module.exports = {
   coverageDirectory: '<rootDir>/reports/coverage',
   preset: 'ts-jest',
   testEnvironment: 'node',
-  testRegex: '.*\\.spec\\.ts$'
+  testRegex: '.*\\.spec\\.ts$',
+  watchPathIgnorePatterns: ['<rootDir>/fixtures', '<rootDir>/packages/[^/]+/src']
 };

--- a/packages/logger/src/diff.ts
+++ b/packages/logger/src/diff.ts
@@ -1,11 +1,25 @@
-import { diff } from 'jest-diff';
+import { diff, diffLinesUnified, diffStringsUnified } from 'jest-diff';
 
 const DIFF_OPTIONS = {
   aAnnotation: 'Expected',
-  bAnnotation: 'Result'
+  bAnnotation: 'Result',
+  expand: false
 };
 
 /** @internal Definitely not stable! Please don't use! */
 export function diffΔ<T>(expected: T, result: T): string | null {
   return diff(expected, result, DIFF_OPTIONS);
+}
+
+/** @internal Definitely not stable! Please don't use! */
+export function diffStringsΔ(expected: string | null, result: string | null): string | null {
+  const expectedStr = expected ?? '';
+  const resultStr = result ?? '';
+
+  // jest-diff recommends using diffLinesUnified if str lengths are above 20,000 for performance
+  if (expectedStr.length > 20_000 || resultStr.length > 20_000) {
+    return diffLinesUnified(expectedStr.split('\n'), resultStr.split('\n'), DIFF_OPTIONS);
+  }
+
+  return diffStringsUnified(expectedStr, resultStr, DIFF_OPTIONS);
 }

--- a/packages/logger/src/index.ts
+++ b/packages/logger/src/index.ts
@@ -1,5 +1,5 @@
 export { codeΔ } from './code';
-export { diffΔ } from './diff';
+export { diffΔ, diffStringsΔ } from './diff';
 export {
   BettererLogger,
   BettererLogMessage,

--- a/packages/reporter/src/components/runs/RunSummary.tsx
+++ b/packages/reporter/src/components/runs/RunSummary.tsx
@@ -1,7 +1,7 @@
 import React, { FC, memo } from 'react';
 
 import { BettererContext, BettererSummary } from '@betterer/betterer';
-import { diffΔ } from '@betterer/logger';
+import { diffStringsΔ } from '@betterer/logger';
 import { Box, Text, TextProps } from 'ink';
 
 import {
@@ -86,10 +86,10 @@ export const RunSummary: FC<RunSummaryProps> = memo(function RunSummary({ contex
           </>
         ) : null}
       </Box>
-      {summary.unexpectedDiff ? (
+      {summary.unexpectedDiff && worse === 0 ? (
         <Box flexDirection="column" paddingBottom={1}>
           <Text color={TEXT_COLOURS.diff}>{unexpectedDiff()}</Text>
-          <Text>{diffΔ(summary.expected, summary.result)}</Text>
+          <Text>{diffStringsΔ(summary.expected, summary.result)}</Text>
         </Box>
       ) : null}
     </>

--- a/test/cli/__snapshots__/betterer-ci.spec.ts.snap
+++ b/test/cli/__snapshots__/betterer-ci.spec.ts.snap
@@ -39,7 +39,7 @@ Array [
    / | /    |_.__//___|/__|/__/___|_|  /___|_|
 
 🌟 Betterer (0ms): 1 test running...
-✅ typescript use strict mode: \\"typescript use strict mode\\" got checked for the first time! (1 issue) 🎉
+✅ typescript use strict mode: \\"typescript use strict mode\\" got checked for the first time! (1,000 issues) 🎉
 
 ",
   "
@@ -50,7 +50,7 @@ Array [
    / | /    |_.__//___|/__|/__/___|_|  /___|_|
 
 🎉 Betterer (0ms): 1 test done!
-✅ typescript use strict mode: \\"typescript use strict mode\\" got checked for the first time! (1 issue) 🎉
+✅ typescript use strict mode: \\"typescript use strict mode\\" got checked for the first time! (1,000 issues) 🎉
 
 ",
   "
@@ -61,7 +61,7 @@ Array [
    / | /    |_.__//___|/__|/__/___|_|  /___|_|
 
 🎉 Betterer (0ms): 1 test done!
-✅ typescript use strict mode: \\"typescript use strict mode\\" got checked for the first time! (1 issue) 🎉
+✅ typescript use strict mode: \\"typescript use strict mode\\" got checked for the first time! (1,000 issues) 🎉
 
 1 test got checked. 🤔
 1 test got checked for the first time! 🎉
@@ -104,7 +104,7 @@ Array [
    / | /    |_.__//___|/__|/__/___|_|  /___|_|
 
 🌟 Betterer (0ms): 1 test running...
-✅ typescript use strict mode: \\"typescript use strict mode\\" stayed the same. (1 issue) 😐
+✅ typescript use strict mode: \\"typescript use strict mode\\" got better! (13 fixed issues, 987 remaining) 😍
 
 ",
   "
@@ -115,7 +115,7 @@ Array [
    / | /    |_.__//___|/__|/__/___|_|  /___|_|
 
 🎉 Betterer (0ms): 1 test done!
-✅ typescript use strict mode: \\"typescript use strict mode\\" stayed the same. (1 issue) 😐
+✅ typescript use strict mode: \\"typescript use strict mode\\" got better! (13 fixed issues, 987 remaining) 😍
 
 ",
   "
@@ -126,22 +126,47 @@ Array [
    / | /    |_.__//___|/__|/__/___|_|  /___|_|
 
 🎉 Betterer (0ms): 1 test done!
-✅ typescript use strict mode: \\"typescript use strict mode\\" stayed the same. (1 issue) 😐
+✅ typescript use strict mode: \\"typescript use strict mode\\" got better! (13 fixed issues, 987 remaining) 😍
 
 1 test got checked. 🤔
-1 test stayed the same. 😐
+1 test got better! 😍
 
 Unexpected diff found:
 - Expected
 + Result
 
+@@ -1,9 +1,9 @@
   // BETTERER RESULTS V2.
   exports[\`typescript use strict mode\`] = {
     value: \`{
--     \\"src/index.ts:1499252024\\": [
--       [2, 12, 1, \\"The left-hand side of an arithmetic operation must be of type /'any/', /'number/', /'bigint/' or an enum type.\\", \\"177604\\"]
-+     \\"src/index.ts:2615232350\\": [
-+       [3, 12, 1, \\"The left-hand side of an arithmetic operation must be of type /'any/', /'number/', /'bigint/' or an enum type.\\", \\"177604\\"]
+-     \\"src/index.ts:3050135194\\": [
++     \\"src/index.ts:34372536\\": [
+        [2, 12, 1, \\"The left-hand side of an arithmetic operation must be of type /'any/', /'number/', /'bigint/' or an enum type.\\", \\"177604\\"],
+        [3, 12, 1, \\"The left-hand side of an arithmetic operation must be of type /'any/', /'number/', /'bigint/' or an enum type.\\", \\"177604\\"],
+        [4, 12, 1, \\"The left-hand side of an arithmetic operation must be of type /'any/', /'number/', /'bigint/' or an enum type.\\", \\"177604\\"],
+        [5, 12, 1, \\"The left-hand side of an arithmetic operation must be of type /'any/', /'number/', /'bigint/' or an enum type.\\", \\"177604\\"],
+        [6, 12, 1, \\"The left-hand side of an arithmetic operation must be of type /'any/', /'number/', /'bigint/' or an enum type.\\", \\"177604\\"],
+@@ -986,23 +986,10 @@
+        [983, 12, 1, \\"The left-hand side of an arithmetic operation must be of type /'any/', /'number/', /'bigint/' or an enum type.\\", \\"177604\\"],
+        [984, 12, 1, \\"The left-hand side of an arithmetic operation must be of type /'any/', /'number/', /'bigint/' or an enum type.\\", \\"177604\\"],
+        [985, 12, 1, \\"The left-hand side of an arithmetic operation must be of type /'any/', /'number/', /'bigint/' or an enum type.\\", \\"177604\\"],
+        [986, 12, 1, \\"The left-hand side of an arithmetic operation must be of type /'any/', /'number/', /'bigint/' or an enum type.\\", \\"177604\\"],
+        [987, 12, 1, \\"The left-hand side of an arithmetic operation must be of type /'any/', /'number/', /'bigint/' or an enum type.\\", \\"177604\\"],
+-       [988, 12, 1, \\"The left-hand side of an arithmetic operation must be of type /'any/', /'number/', /'bigint/' or an enum type.\\", \\"177604\\"],
+-       [989, 12, 1, \\"The left-hand side of an arithmetic operation must be of type /'any/', /'number/', /'bigint/' or an enum type.\\", \\"177604\\"],
+-       [990, 12, 1, \\"The left-hand side of an arithmetic operation must be of type /'any/', /'number/', /'bigint/' or an enum type.\\", \\"177604\\"],
+-       [991, 12, 1, \\"The left-hand side of an arithmetic operation must be of type /'any/', /'number/', /'bigint/' or an enum type.\\", \\"177604\\"],
+-       [992, 12, 1, \\"The left-hand side of an arithmetic operation must be of type /'any/', /'number/', /'bigint/' or an enum type.\\", \\"177604\\"],
+-       [993, 12, 1, \\"The left-hand side of an arithmetic operation must be of type /'any/', /'number/', /'bigint/' or an enum type.\\", \\"177604\\"],
+-       [994, 12, 1, \\"The left-hand side of an arithmetic operation must be of type /'any/', /'number/', /'bigint/' or an enum type.\\", \\"177604\\"],
+-       [995, 12, 1, \\"The left-hand side of an arithmetic operation must be of type /'any/', /'number/', /'bigint/' or an enum type.\\", \\"177604\\"],
+-       [996, 12, 1, \\"The left-hand side of an arithmetic operation must be of type /'any/', /'number/', /'bigint/' or an enum type.\\", \\"177604\\"],
+-       [997, 12, 1, \\"The left-hand side of an arithmetic operation must be of type /'any/', /'number/', /'bigint/' or an enum type.\\", \\"177604\\"],
+-       [998, 12, 1, \\"The left-hand side of an arithmetic operation must be of type /'any/', /'number/', /'bigint/' or an enum type.\\", \\"177604\\"],
+-       [999, 12, 1, \\"The left-hand side of an arithmetic operation must be of type /'any/', /'number/', /'bigint/' or an enum type.\\", \\"177604\\"],
+-       [1000, 12, 1, \\"The left-hand side of an arithmetic operation must be of type /'any/', /'number/', /'bigint/' or an enum type.\\", \\"177604\\"],
+-       [1001, 12, 1, \\"The left-hand side of an arithmetic operation must be of type /'any/', /'number/', /'bigint/' or an enum type.\\", \\"177604\\"]
++       [988, 12, 1, \\"The left-hand side of an arithmetic operation must be of type /'any/', /'number/', /'bigint/' or an enum type.\\", \\"177604\\"]
       ]
     }\`
   };
@@ -524,8 +549,8 @@ Unexpected diff found:
   exports[\`typescript use strict mode\`] = {
     value: \`{
 -     \\"src/index.ts:1499252024\\": [
--       [2, 12, 1, \\"The left-hand side of an arithmetic operation must be of type /'any/', /'number/', /'bigint/' or an enum type.\\", \\"177604\\"]
 +     \\"src/index.ts:2615232350\\": [
+-       [2, 12, 1, \\"The left-hand side of an arithmetic operation must be of type /'any/', /'number/', /'bigint/' or an enum type.\\", \\"177604\\"]
 +       [3, 12, 1, \\"The left-hand side of an arithmetic operation must be of type /'any/', /'number/', /'bigint/' or an enum type.\\", \\"177604\\"]
       ]
     }\`


### PR DESCRIPTION
Fixes #795

This does two things like the issue mentions:

* Only logs a results file diff if nothing has gotten worse. This has just been noise in CI for us - if something has been reported to get worse, the diff can be ignored because there's _obviously_ a diff, since things got worse. 
    * Note that this is already how things behave if one test has gotten worse _and_ has a diff - it's only when you have multiple tests that it'll start logging diffs right now. So, the consistency makes sense to me. 
* If it does log a diff, only logs the part that changed.

Bonuses:

* Better `watchPathIgnorePatterns` (only reruns the watch after tsc has recompiled things)
* Uses better diff reporter from jest-diff, with colorization and character-diffs, deduplication, etc