### PR TITLE
fix(betterer 🐛): use repository root when rewriting paths in results file

### DIFF
--- a/goldens/api/betterer.api.md
+++ b/goldens/api/betterer.api.md
@@ -43,6 +43,7 @@ export interface BettererConfigBase {
     reporter: BettererReporter;
     resultsPath: string;
     tsconfigPath: string | null;
+    versionControlPath: string;
     workers: number;
 }
 

--- a/packages/betterer/src/config/index.ts
+++ b/packages/betterer/src/config/index.ts
@@ -1,10 +1,4 @@
-export {
-  createInitialConfig,
-  createFinalConfig,
-  createMergeConfig,
-  createWorkerConfig,
-  overrideConfig
-} from './config';
+export { createConfig, createMergeConfig, createWorkerConfig, overrideConfig } from './config';
 export {
   BettererConfig,
   BettererConfigBase,

--- a/packages/betterer/src/config/types.ts
+++ b/packages/betterer/src/config/types.ts
@@ -81,6 +81,10 @@ export interface BettererConfigBase {
    */
   tsconfigPath: string | null;
   /**
+   * The absolute path to the root directory of the repository.
+   */
+  versionControlPath: string;
+  /**
    * The number of {@link https://nodejs.org/api/worker_threads.html | worker threads} to use when
    * running **Betterer**.
    */

--- a/packages/betterer/src/context/context.ts
+++ b/packages/betterer/src/context/context.ts
@@ -82,8 +82,12 @@ export class BettererContextΩ implements BettererContext {
   }
 
   public async runOnce(): Promise<BettererSuiteSummary> {
-    await this.run([], true);
-    return this.stop();
+    try {
+      await this.run([], true);
+      return this.stop();
+    } finally {
+      await this._destroy();
+    }
   }
 
   public async stop(): Promise<BettererSuiteSummary> {

--- a/packages/betterer/src/context/context.ts
+++ b/packages/betterer/src/context/context.ts
@@ -84,7 +84,8 @@ export class BettererContextΩ implements BettererContext {
   public async runOnce(): Promise<BettererSuiteSummary> {
     try {
       await this.run([], true);
-      return this.stop();
+      const summary = await this.stop();
+      return summary;
     } finally {
       await this._destroy();
     }

--- a/packages/betterer/src/fs/git.ts
+++ b/packages/betterer/src/fs/git.ts
@@ -58,7 +58,7 @@ export class BettererGitΩ implements BettererVersionControl {
     return this._filePaths;
   }
 
-  public async init(configPaths: BettererFilePaths): Promise<void> {
+  public async init(configPaths: BettererFilePaths): Promise<string> {
     this._configPaths = configPaths;
     this._gitDir = await this._findGitRoot();
     this._rootDir = path.dirname(this._gitDir);
@@ -66,6 +66,7 @@ export class BettererGitΩ implements BettererVersionControl {
     this._cache = new BettererFileCacheΩ(this._configPaths);
     await this._init(this._git);
     await this.sync();
+    return this._rootDir;
   }
 
   public async sync(): Promise<void> {

--- a/packages/betterer/src/globals.ts
+++ b/packages/betterer/src/globals.ts
@@ -8,20 +8,16 @@ import { BettererGlobals } from './types';
 
 export async function createGlobals(options: unknown = {}): Promise<BettererGlobals> {
   const reporter = loadDefaultReporter();
+  const versionControl = createVersionControl();
   try {
-    const versionControl = createVersionControl();
     const config = await createConfig(options, versionControl);
-    try {
-      if (config.cache) {
-        await versionControl.enableCache(config.cachePath);
-      }
-      const resultsFile = await BettererResultsFileΩ.create(config.resultsPath, versionControl);
-      return { config, resultsFile, versionControl };
-    } catch (error) {
-      await versionControl.destroy();
-      throw error;
+    if (config.cache) {
+      await versionControl.enableCache(config.cachePath);
     }
+    const resultsFile = await BettererResultsFileΩ.create(config.resultsPath, versionControl);
+    return { config, resultsFile, versionControl };
   } catch (error) {
+    await versionControl.destroy();
     await reporter.configError(options, error as BettererError);
     throw error;
   }

--- a/packages/betterer/src/globals.ts
+++ b/packages/betterer/src/globals.ts
@@ -1,6 +1,6 @@
 import { BettererError } from '@betterer/errors';
 
-import { createInitialConfig, createFinalConfig } from './config';
+import { createConfig } from './config';
 import { createVersionControl } from './fs';
 import { loadDefaultReporter } from './reporters';
 import { BettererResultsFileΩ } from './results';
@@ -9,10 +9,9 @@ import { BettererGlobals } from './types';
 export async function createGlobals(options: unknown = {}): Promise<BettererGlobals> {
   const reporter = loadDefaultReporter();
   try {
-    const config = await createInitialConfig(options);
     const versionControl = createVersionControl();
+    const config = await createConfig(options, versionControl);
     try {
-      await createFinalConfig(options, config, versionControl);
       if (config.cache) {
         await versionControl.enableCache(config.cachePath);
       }

--- a/packages/betterer/src/run/worker-run-config.ts
+++ b/packages/betterer/src/run/worker-run-config.ts
@@ -16,6 +16,7 @@ export function createWorkerRunConfig(config: BettererConfig): BettererWorkerRun
     strict: config.strict,
     tsconfigPath: config.tsconfigPath,
     update: config.update,
+    versionControlPath: config.versionControlPath,
     watch: config.watch,
     workers: config.workers
   };

--- a/packages/betterer/src/run/worker-run.ts
+++ b/packages/betterer/src/run/worker-run.ts
@@ -164,7 +164,7 @@ export class BettererWorkerRunΩ implements BettererRun {
       if (shouldPrint) {
         const toPrint = isFailed || isSkipped || isWorse ? this.expected : (result as BettererResultΩ);
         const toPrintSerialised = this.test.serialiser.serialise(toPrint.value, config.resultsPath);
-        printed = forceRelativePaths(await this.test.printer(toPrintSerialised), config.cwd);
+        printed = forceRelativePaths(await this.test.printer(toPrintSerialised), config.versionControlPath);
       }
 
       if (this.testMeta.isFileTest) {

--- a/test/config-validation.spec.ts
+++ b/test/config-validation.spec.ts
@@ -13,7 +13,9 @@ jest.mock('os', () => {
 
 describe('betterer', () => {
   it('should throw when there is invalid config', async () => {
-    const { cleanup, logs, paths } = await createFixture('config-validation');
+    const { cleanup, logs, paths } = await createFixture('config-validation', {
+      '.betterer.js': ''
+    });
     const configPaths = [paths.config];
     const resultsPath = paths.results;
 


### PR DESCRIPTION
Fixes #930 