### PR TITLE
Correctly use the `cwd` option when looking for the `.git` root

### DIFF
--- a/packages/betterer/src/config/config.ts
+++ b/packages/betterer/src/config/config.ts
@@ -96,7 +96,7 @@ async function createBaseConfig(
   const workers = validateWorkers(options);
 
   const validatedConfigPaths = validateConfigPaths(cwd, configPaths);
-  const versionControlPath = await versionControl.init(validatedConfigPaths);
+  const versionControlPath = await versionControl.init(validatedConfigPaths, cwd);
 
   return {
     cache,

--- a/packages/betterer/src/fs/git.ts
+++ b/packages/betterer/src/fs/git.ts
@@ -58,9 +58,9 @@ export class BettererGitΩ implements BettererVersionControl {
     return this._filePaths;
   }
 
-  public async init(configPaths: BettererFilePaths): Promise<string> {
+  public async init(configPaths: BettererFilePaths, cwd: string): Promise<string> {
     this._configPaths = configPaths;
-    this._gitDir = await this._findGitRoot();
+    this._gitDir = await this._findGitRoot(cwd);
     this._rootDir = path.dirname(this._gitDir);
     this._git = simpleGit(this._rootDir);
     this._cache = new BettererFileCacheΩ(this._configPaths);
@@ -78,8 +78,8 @@ export class BettererGitΩ implements BettererVersionControl {
     this._syncing = null;
   }
 
-  private async _findGitRoot(): Promise<string> {
-    let dir = process.cwd();
+  private async _findGitRoot(cwd: string): Promise<string> {
+    let dir = cwd;
     while (dir !== path.parse(dir).root) {
       try {
         const gitPath = path.join(dir, '.git');


### PR DESCRIPTION
I've been trying to use Betterer in a github action (for context, see https://github.com/grafana/grafana-github-actions/blob/main/backport/backport.ts#L95)

In doing so I noticed that it's impossible to run Betterer from outside of the repo itself even if you specify a `cwd` inside the repo. I think that's because the `cwd` is never passed to `findGitRoot` and it only ever uses `process.cwd()`. In comparison, it finds the config files correctly because `cwd` is passed through to `validateConfigPaths`. 