### PR TITLE
Remove trailing space in results file

### DIFF
--- a/packages/betterer/src/results/print.ts
+++ b/packages/betterer/src/results/print.ts
@@ -17,7 +17,7 @@ const ESCAPE_REPLACERS: Record<string, string> = {
 };
 
 const RESULTS_HEADER = `// BETTERER RESULTS V2.
-// 
+//
 // If this file contains merge conflicts, use \`betterer merge\` to automatically resolve them:
 // https://phenomnomnominal.github.io/betterer/docs/results-file/#merge
 //`;

--- a/test/__snapshots__/angular.spec.ts.snap
+++ b/test/__snapshots__/angular.spec.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`betterer should report the status of the Angular compiler in strict mode 1`] = `
 "// BETTERER RESULTS V2.
-// 
+//
 // If this file contains merge conflicts, use \`betterer merge\` to automatically resolve them:
 // https://phenomnomnominal.github.io/betterer/docs/results-file/#merge
 //

--- a/test/__snapshots__/better-result.spec.ts.snap
+++ b/test/__snapshots__/better-result.spec.ts.snap
@@ -89,7 +89,7 @@ Array [
 
 exports[`betterer should work when a result gets better 2`] = `
 "// BETTERER RESULTS V2.
-// 
+//
 // If this file contains merge conflicts, use \`betterer merge\` to automatically resolve them:
 // https://phenomnomnominal.github.io/betterer/docs/results-file/#merge
 //

--- a/test/__snapshots__/better-test-change.spec.ts.snap
+++ b/test/__snapshots__/better-test-change.spec.ts.snap
@@ -125,7 +125,7 @@ Array [
 
 exports[`betterer should work when a test changes and makes the result better 2`] = `
 "// BETTERER RESULTS V2.
-// 
+//
 // If this file contains merge conflicts, use \`betterer merge\` to automatically resolve them:
 // https://phenomnomnominal.github.io/betterer/docs/results-file/#merge
 //

--- a/test/__snapshots__/cache-deleted-file.spec.ts.snap
+++ b/test/__snapshots__/cache-deleted-file.spec.ts.snap
@@ -25,7 +25,7 @@ exports[`betterer should remove files from the cache when they are deleted 2`] =
 
 exports[`betterer should remove files from the cache when they are deleted 3`] = `
 "// BETTERER RESULTS V2.
-// 
+//
 // If this file contains merge conflicts, use \`betterer merge\` to automatically resolve them:
 // https://phenomnomnominal.github.io/betterer/docs/results-file/#merge
 //
@@ -53,7 +53,7 @@ exports[`betterer should remove files from the cache when they are deleted 4`] =
 
 exports[`betterer should remove files from the cache when they are deleted 5`] = `
 "// BETTERER RESULTS V2.
-// 
+//
 // If this file contains merge conflicts, use \`betterer merge\` to automatically resolve them:
 // https://phenomnomnominal.github.io/betterer/docs/results-file/#merge
 //

--- a/test/__snapshots__/cache-path.spec.ts.snap
+++ b/test/__snapshots__/cache-path.spec.ts.snap
@@ -24,7 +24,7 @@ exports[`betterer should write a cache file to a different path 2`] = `
 
 exports[`betterer should write a cache file to a different path 3`] = `
 "// BETTERER RESULTS V2.
-// 
+//
 // If this file contains merge conflicts, use \`betterer merge\` to automatically resolve them:
 // https://phenomnomnominal.github.io/betterer/docs/results-file/#merge
 //
@@ -52,7 +52,7 @@ exports[`betterer should write a cache file to a different path 4`] = `
 
 exports[`betterer should write a cache file to a different path 5`] = `
 "// BETTERER RESULTS V2.
-// 
+//
 // If this file contains merge conflicts, use \`betterer merge\` to automatically resolve them:
 // https://phenomnomnominal.github.io/betterer/docs/results-file/#merge
 //

--- a/test/__snapshots__/cache.spec.ts.snap
+++ b/test/__snapshots__/cache.spec.ts.snap
@@ -24,7 +24,7 @@ exports[`betterer should write a cache file 2`] = `
 
 exports[`betterer should write a cache file 3`] = `
 "// BETTERER RESULTS V2.
-// 
+//
 // If this file contains merge conflicts, use \`betterer merge\` to automatically resolve them:
 // https://phenomnomnominal.github.io/betterer/docs/results-file/#merge
 //
@@ -52,7 +52,7 @@ exports[`betterer should write a cache file 4`] = `
 
 exports[`betterer should write a cache file 5`] = `
 "// BETTERER RESULTS V2.
-// 
+//
 // If this file contains merge conflicts, use \`betterer merge\` to automatically resolve them:
 // https://phenomnomnominal.github.io/betterer/docs/results-file/#merge
 //

--- a/test/__snapshots__/complete.spec.ts.snap
+++ b/test/__snapshots__/complete.spec.ts.snap
@@ -132,7 +132,7 @@ Array [
 
 exports[`betterer should mark a test as complete when it reaches its goal 2`] = `
 "// BETTERER RESULTS V2.
-// 
+//
 // If this file contains merge conflicts, use \`betterer merge\` to automatically resolve them:
 // https://phenomnomnominal.github.io/betterer/docs/results-file/#merge
 //"

--- a/test/__snapshots__/config-named-exports.spec.ts.snap
+++ b/test/__snapshots__/config-named-exports.spec.ts.snap
@@ -125,7 +125,7 @@ Array [
 
 exports[`betterer should work with named exports in the config file 2`] = `
 "// BETTERER RESULTS V2.
-// 
+//
 // If this file contains merge conflicts, use \`betterer merge\` to automatically resolve them:
 // https://phenomnomnominal.github.io/betterer/docs/results-file/#merge
 //

--- a/test/__snapshots__/config-ts-esm.spec.ts.snap
+++ b/test/__snapshots__/config-ts-esm.spec.ts.snap
@@ -125,7 +125,7 @@ Array [
 
 exports[`betterer should work with a .betterer.ts file that uses ES modules 2`] = `
 "// BETTERER RESULTS V2.
-// 
+//
 // If this file contains merge conflicts, use \`betterer merge\` to automatically resolve them:
 // https://phenomnomnominal.github.io/betterer/docs/results-file/#merge
 //

--- a/test/__snapshots__/config-ts.spec.ts.snap
+++ b/test/__snapshots__/config-ts.spec.ts.snap
@@ -125,7 +125,7 @@ Array [
 
 exports[`betterer should work with a .betterer.ts file 2`] = `
 "// BETTERER RESULTS V2.
-// 
+//
 // If this file contains merge conflicts, use \`betterer merge\` to automatically resolve them:
 // https://phenomnomnominal.github.io/betterer/docs/results-file/#merge
 //

--- a/test/__snapshots__/conflict.spec.ts.snap
+++ b/test/__snapshots__/conflict.spec.ts.snap
@@ -66,7 +66,7 @@ Array [
 
 exports[`betterer should work when there is a merge conflict in the results file 2`] = `
 "// BETTERER RESULTS V2.
-// 
+//
 // If this file contains merge conflicts, use \`betterer merge\` to automatically resolve them:
 // https://phenomnomnominal.github.io/betterer/docs/results-file/#merge
 //

--- a/test/__snapshots__/coverage-files-same.spec.ts.snap
+++ b/test/__snapshots__/coverage-files-same.spec.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`betterer should report a stable per-file coverage result 1`] = `
 "// BETTERER RESULTS V2.
-// 
+//
 // If this file contains merge conflicts, use \`betterer merge\` to automatically resolve them:
 // https://phenomnomnominal.github.io/betterer/docs/results-file/#merge
 //

--- a/test/__snapshots__/coverage-total.spec.ts.snap
+++ b/test/__snapshots__/coverage-total.spec.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`betterer should report the total coverage 1`] = `
 "// BETTERER RESULTS V2.
-// 
+//
 // If this file contains merge conflicts, use \`betterer merge\` to automatically resolve them:
 // https://phenomnomnominal.github.io/betterer/docs/results-file/#merge
 //

--- a/test/__snapshots__/deadline-file-test-expired.spec.ts.snap
+++ b/test/__snapshots__/deadline-file-test-expired.spec.ts.snap
@@ -69,7 +69,7 @@ Array [
 
 exports[`betterer should mark a file test as expired when it is past its deadline 2`] = `
 "// BETTERER RESULTS V2.
-// 
+//
 // If this file contains merge conflicts, use \`betterer merge\` to automatically resolve them:
 // https://phenomnomnominal.github.io/betterer/docs/results-file/#merge
 //

--- a/test/__snapshots__/deadline-future.spec.ts.snap
+++ b/test/__snapshots__/deadline-future.spec.ts.snap
@@ -66,7 +66,7 @@ Array [
 
 exports[`betterer should do nothing when a test is not past its deadline 2`] = `
 "// BETTERER RESULTS V2.
-// 
+//
 // If this file contains merge conflicts, use \`betterer merge\` to automatically resolve them:
 // https://phenomnomnominal.github.io/betterer/docs/results-file/#merge
 //

--- a/test/__snapshots__/deadline-test-expired.spec.ts.snap
+++ b/test/__snapshots__/deadline-test-expired.spec.ts.snap
@@ -69,7 +69,7 @@ Array [
 
 exports[`betterer should mark a test as expired when it is past its deadline 2`] = `
 "// BETTERER RESULTS V2.
-// 
+//
 // If this file contains merge conflicts, use \`betterer merge\` to automatically resolve them:
 // https://phenomnomnominal.github.io/betterer/docs/results-file/#merge
 //

--- a/test/__snapshots__/eslint-complex-project.spec.ts.snap
+++ b/test/__snapshots__/eslint-complex-project.spec.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`betterer should report the status of a new eslint rule with a complex set up 1`] = `
 "// BETTERER RESULTS V2.
-// 
+//
 // If this file contains merge conflicts, use \`betterer merge\` to automatically resolve them:
 // https://phenomnomnominal.github.io/betterer/docs/results-file/#merge
 //

--- a/test/__snapshots__/eslint-complex-rule.spec.ts.snap
+++ b/test/__snapshots__/eslint-complex-rule.spec.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`betterer should handle complex eslint rule options 1`] = `
 "// BETTERER RESULTS V2.
-// 
+//
 // If this file contains merge conflicts, use \`betterer merge\` to automatically resolve them:
 // https://phenomnomnominal.github.io/betterer/docs/results-file/#merge
 //

--- a/test/__snapshots__/eslint.spec.ts.snap
+++ b/test/__snapshots__/eslint.spec.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`betterer should report the status of a new eslint rule 1`] = `
 "// BETTERER RESULTS V2.
-// 
+//
 // If this file contains merge conflicts, use \`betterer merge\` to automatically resolve them:
 // https://phenomnomnominal.github.io/betterer/docs/results-file/#merge
 //

--- a/test/__snapshots__/exclude-files.spec.ts.snap
+++ b/test/__snapshots__/exclude-files.spec.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`betterer should exclude specific files from results 1`] = `
 "// BETTERER RESULTS V2.
-// 
+//
 // If this file contains merge conflicts, use \`betterer merge\` to automatically resolve them:
 // https://phenomnomnominal.github.io/betterer/docs/results-file/#merge
 //
@@ -21,7 +21,7 @@ exports[\`test\`] = {
 
 exports[`betterer should exclude specific files from results 2`] = `
 "// BETTERER RESULTS V2.
-// 
+//
 // If this file contains merge conflicts, use \`betterer merge\` to automatically resolve them:
 // https://phenomnomnominal.github.io/betterer/docs/results-file/#merge
 //

--- a/test/__snapshots__/exclude-global.spec.ts.snap
+++ b/test/__snapshots__/exclude-global.spec.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`betterer should handle a global exclude 1`] = `
 "// BETTERER RESULTS V2.
-// 
+//
 // If this file contains merge conflicts, use \`betterer merge\` to automatically resolve them:
 // https://phenomnomnominal.github.io/betterer/docs/results-file/#merge
 //
@@ -21,7 +21,7 @@ exports[\`test\`] = {
 
 exports[`betterer should handle a global exclude 2`] = `
 "// BETTERER RESULTS V2.
-// 
+//
 // If this file contains merge conflicts, use \`betterer merge\` to automatically resolve them:
 // https://phenomnomnominal.github.io/betterer/docs/results-file/#merge
 //

--- a/test/__snapshots__/file-test-constraint.spec.ts.snap
+++ b/test/__snapshots__/file-test-constraint.spec.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`betterer should let you override the constraint of a file test 1`] = `
 "// BETTERER RESULTS V2.
-// 
+//
 // If this file contains merge conflicts, use \`betterer merge\` to automatically resolve them:
 // https://phenomnomnominal.github.io/betterer/docs/results-file/#merge
 //

--- a/test/__snapshots__/file-test-goal.spec.ts.snap
+++ b/test/__snapshots__/file-test-goal.spec.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`betterer should let you override the goal of a file test 1`] = `
 "// BETTERER RESULTS V2.
-// 
+//
 // If this file contains merge conflicts, use \`betterer merge\` to automatically resolve them:
 // https://phenomnomnominal.github.io/betterer/docs/results-file/#merge
 //

--- a/test/__snapshots__/file-test-line-endings.spec.ts.snap
+++ b/test/__snapshots__/file-test-line-endings.spec.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`betterer should normalise line endings within issues 1`] = `
 "// BETTERER RESULTS V2.
-// 
+//
 // If this file contains merge conflicts, use \`betterer merge\` to automatically resolve them:
 // https://phenomnomnominal.github.io/betterer/docs/results-file/#merge
 //

--- a/test/__snapshots__/file-test-sort-absolute.spec.ts.snap
+++ b/test/__snapshots__/file-test-sort-absolute.spec.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`betterer should sort files by their file path correctly with absolute paths 1`] = `
 "// BETTERER RESULTS V2.
-// 
+//
 // If this file contains merge conflicts, use \`betterer merge\` to automatically resolve them:
 // https://phenomnomnominal.github.io/betterer/docs/results-file/#merge
 //

--- a/test/__snapshots__/file-test-sort-all.spec.ts.snap
+++ b/test/__snapshots__/file-test-sort-all.spec.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`betterer should sort files by their file path 1`] = `
 "// BETTERER RESULTS V2.
-// 
+//
 // If this file contains merge conflicts, use \`betterer merge\` to automatically resolve them:
 // https://phenomnomnominal.github.io/betterer/docs/results-file/#merge
 //

--- a/test/__snapshots__/file-test-sort-subset.spec.ts.snap
+++ b/test/__snapshots__/file-test-sort-subset.spec.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`betterer should sort files by their file path even when only running on a single file 1`] = `
 "// BETTERER RESULTS V2.
-// 
+//
 // If this file contains merge conflicts, use \`betterer merge\` to automatically resolve them:
 // https://phenomnomnominal.github.io/betterer/docs/results-file/#merge
 //

--- a/test/__snapshots__/filter-only.spec.ts.snap
+++ b/test/__snapshots__/filter-only.spec.ts.snap
@@ -98,7 +98,7 @@ Array [
 
 exports[`betterer should run only specific tests called with only() 2`] = `
 "// BETTERER RESULTS V2.
-// 
+//
 // If this file contains merge conflicts, use \`betterer merge\` to automatically resolve them:
 // https://phenomnomnominal.github.io/betterer/docs/results-file/#merge
 //

--- a/test/__snapshots__/filter-skip.spec.ts.snap
+++ b/test/__snapshots__/filter-skip.spec.ts.snap
@@ -89,7 +89,7 @@ Array [
 
 exports[`betterer should not run a specific test called with skip() 2`] = `
 "// BETTERER RESULTS V2.
-// 
+//
 // If this file contains merge conflicts, use \`betterer merge\` to automatically resolve them:
 // https://phenomnomnominal.github.io/betterer/docs/results-file/#merge
 //

--- a/test/__snapshots__/include-global.spec.ts.snap
+++ b/test/__snapshots__/include-global.spec.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`betterer should handle a global include 1`] = `
 "// BETTERER RESULTS V2.
-// 
+//
 // If this file contains merge conflicts, use \`betterer merge\` to automatically resolve them:
 // https://phenomnomnominal.github.io/betterer/docs/results-file/#merge
 //
@@ -18,7 +18,7 @@ exports[\`test\`] = {
 
 exports[`betterer should handle a global include 2`] = `
 "// BETTERER RESULTS V2.
-// 
+//
 // If this file contains merge conflicts, use \`betterer merge\` to automatically resolve them:
 // https://phenomnomnominal.github.io/betterer/docs/results-file/#merge
 //

--- a/test/__snapshots__/printer-pathological.spec.ts.snap
+++ b/test/__snapshots__/printer-pathological.spec.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`betterer should handle printing for pathological cases 1`] = `
 "// BETTERER RESULTS V2.
-// 
+//
 // If this file contains merge conflicts, use \`betterer merge\` to automatically resolve them:
 // https://phenomnomnominal.github.io/betterer/docs/results-file/#merge
 //

--- a/test/__snapshots__/regexp-message.spec.ts.snap
+++ b/test/__snapshots__/regexp-message.spec.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`betterer should report the existence of RegExp matches, with a custom issue message 1`] = `
 "// BETTERER RESULTS V2.
-// 
+//
 // If this file contains merge conflicts, use \`betterer merge\` to automatically resolve them:
 // https://phenomnomnominal.github.io/betterer/docs/results-file/#merge
 //

--- a/test/__snapshots__/regexp.spec.ts.snap
+++ b/test/__snapshots__/regexp.spec.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`betterer should report the existence of RegExp matches 1`] = `
 "// BETTERER RESULTS V2.
-// 
+//
 // If this file contains merge conflicts, use \`betterer merge\` to automatically resolve them:
 // https://phenomnomnominal.github.io/betterer/docs/results-file/#merge
 //

--- a/test/__snapshots__/results-escape.spec.ts.snap
+++ b/test/__snapshots__/results-escape.spec.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`betterer should escape interpolation characters in the result file 1`] = `
 "// BETTERER RESULTS V2.
-// 
+//
 // If this file contains merge conflicts, use \`betterer merge\` to automatically resolve them:
 // https://phenomnomnominal.github.io/betterer/docs/results-file/#merge
 //

--- a/test/__snapshots__/results-path.spec.ts.snap
+++ b/test/__snapshots__/results-path.spec.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`betterer should write a results file to a different path 1`] = `
 "// BETTERER RESULTS V2.
-// 
+//
 // If this file contains merge conflicts, use \`betterer merge\` to automatically resolve them:
 // https://phenomnomnominal.github.io/betterer/docs/results-file/#merge
 //

--- a/test/__snapshots__/same-move-file.spec.ts.snap
+++ b/test/__snapshots__/same-move-file.spec.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`betterer should stay the same when a file is moved 1`] = `
 "// BETTERER RESULTS V2.
-// 
+//
 // If this file contains merge conflicts, use \`betterer merge\` to automatically resolve them:
 // https://phenomnomnominal.github.io/betterer/docs/results-file/#merge
 //
@@ -18,7 +18,7 @@ exports[\`test\`] = {
 
 exports[`betterer should stay the same when a file is moved 2`] = `
 "// BETTERER RESULTS V2.
-// 
+//
 // If this file contains merge conflicts, use \`betterer merge\` to automatically resolve them:
 // https://phenomnomnominal.github.io/betterer/docs/results-file/#merge
 //

--- a/test/__snapshots__/same-move-issue.spec.ts.snap
+++ b/test/__snapshots__/same-move-issue.spec.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`betterer should stay the same when an issue is moved 1`] = `
 "// BETTERER RESULTS V2.
-// 
+//
 // If this file contains merge conflicts, use \`betterer merge\` to automatically resolve them:
 // https://phenomnomnominal.github.io/betterer/docs/results-file/#merge
 //
@@ -18,7 +18,7 @@ exports[\`test\`] = {
 
 exports[`betterer should stay the same when an issue is moved 2`] = `
 "// BETTERER RESULTS V2.
-// 
+//
 // If this file contains merge conflicts, use \`betterer merge\` to automatically resolve them:
 // https://phenomnomnominal.github.io/betterer/docs/results-file/#merge
 //

--- a/test/__snapshots__/same-move-issues.spec.ts.snap
+++ b/test/__snapshots__/same-move-issues.spec.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`betterer should stay the same when multiple issues are moved 1`] = `
 "// BETTERER RESULTS V2.
-// 
+//
 // If this file contains merge conflicts, use \`betterer merge\` to automatically resolve them:
 // https://phenomnomnominal.github.io/betterer/docs/results-file/#merge
 //
@@ -19,7 +19,7 @@ exports[\`test\`] = {
 
 exports[`betterer should stay the same when multiple issues are moved 2`] = `
 "// BETTERER RESULTS V2.
-// 
+//
 // If this file contains merge conflicts, use \`betterer merge\` to automatically resolve them:
 // https://phenomnomnominal.github.io/betterer/docs/results-file/#merge
 //

--- a/test/__snapshots__/same-result.spec.ts.snap
+++ b/test/__snapshots__/same-result.spec.ts.snap
@@ -85,7 +85,7 @@ Array [
 
 exports[`betterer should work when a test is the same 2`] = `
 "// BETTERER RESULTS V2.
-// 
+//
 // If this file contains merge conflicts, use \`betterer merge\` to automatically resolve them:
 // https://phenomnomnominal.github.io/betterer/docs/results-file/#merge
 //

--- a/test/__snapshots__/styelint.spec.ts.snap
+++ b/test/__snapshots__/styelint.spec.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`betterer should report the status of a new stylelint rule 1`] = `
 "// BETTERER RESULTS V2.
-// 
+//
 // If this file contains merge conflicts, use \`betterer merge\` to automatically resolve them:
 // https://phenomnomnominal.github.io/betterer/docs/results-file/#merge
 //

--- a/test/__snapshots__/tsquery-message.spec.ts.snap
+++ b/test/__snapshots__/tsquery-message.spec.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`betterer should report the existence of TSQuery matches 1`] = `
 "// BETTERER RESULTS V2.
-// 
+//
 // If this file contains merge conflicts, use \`betterer merge\` to automatically resolve them:
 // https://phenomnomnominal.github.io/betterer/docs/results-file/#merge
 //

--- a/test/__snapshots__/tsquery.spec.ts.snap
+++ b/test/__snapshots__/tsquery.spec.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`betterer should report the existence of TSQuery matches 1`] = `
 "// BETTERER RESULTS V2.
-// 
+//
 // If this file contains merge conflicts, use \`betterer merge\` to automatically resolve them:
 // https://phenomnomnominal.github.io/betterer/docs/results-file/#merge
 //

--- a/test/__snapshots__/typescript-strict.spec.ts.snap
+++ b/test/__snapshots__/typescript-strict.spec.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`betterer should report the status of the TypeScript compiler in strict mode 1`] = `
 "// BETTERER RESULTS V2.
-// 
+//
 // If this file contains merge conflicts, use \`betterer merge\` to automatically resolve them:
 // https://phenomnomnominal.github.io/betterer/docs/results-file/#merge
 //

--- a/test/__snapshots__/typescript.spec.ts.snap
+++ b/test/__snapshots__/typescript.spec.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`betterer should report the status of the TypeScript compiler 1`] = `
 "// BETTERER RESULTS V2.
-// 
+//
 // If this file contains merge conflicts, use \`betterer merge\` to automatically resolve them:
 // https://phenomnomnominal.github.io/betterer/docs/results-file/#merge
 //

--- a/test/__snapshots__/workers.spec.ts.snap
+++ b/test/__snapshots__/workers.spec.ts.snap
@@ -122,7 +122,7 @@ You should try to fix the new issues! As a last resort, you can run \`betterer -
 
 exports[`betterer should run tests in workers 2`] = `
 "// BETTERER RESULTS V2.
-// 
+//
 // If this file contains merge conflicts, use \`betterer merge\` to automatically resolve them:
 // https://phenomnomnominal.github.io/betterer/docs/results-file/#merge
 //

--- a/test/__snapshots__/worse-result.spec.ts.snap
+++ b/test/__snapshots__/worse-result.spec.ts.snap
@@ -119,7 +119,7 @@ You should try to fix the new issues! As a last resort, you can run \`betterer -
 
 exports[`betterer should work when a test gets worse 2`] = `
 "// BETTERER RESULTS V2.
-// 
+//
 // If this file contains merge conflicts, use \`betterer merge\` to automatically resolve them:
 // https://phenomnomnominal.github.io/betterer/docs/results-file/#merge
 //

--- a/test/__snapshots__/worse-strict.spec.ts.snap
+++ b/test/__snapshots__/worse-strict.spec.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`betterer should stay worse if an update is not allowed 1`] = `
 "// BETTERER RESULTS V2.
-// 
+//
 // If this file contains merge conflicts, use \`betterer merge\` to automatically resolve them:
 // https://phenomnomnominal.github.io/betterer/docs/results-file/#merge
 //

--- a/test/__snapshots__/worse-update.spec.ts.snap
+++ b/test/__snapshots__/worse-update.spec.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`betterer should not stay worse if an update is forced 1`] = `
 "// BETTERER RESULTS V2.
-// 
+//
 // If this file contains merge conflicts, use \`betterer merge\` to automatically resolve them:
 // https://phenomnomnominal.github.io/betterer/docs/results-file/#merge
 //

--- a/test/cli/__snapshots__/ci-complete.spec.ts.snap
+++ b/test/cli/__snapshots__/ci-complete.spec.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`betterer ci should work when a test is already complete 1`] = `
 "// BETTERER RESULTS V2.
-// 
+//
 // If this file contains merge conflicts, use \`betterer merge\` to automatically resolve them:
 // https://phenomnomnominal.github.io/betterer/docs/results-file/#merge
 //
@@ -18,7 +18,7 @@ exports[\`test\`] = {
 
 exports[`betterer ci should work when a test is already complete 2`] = `
 "// BETTERER RESULTS V2.
-// 
+//
 // If this file contains merge conflicts, use \`betterer merge\` to automatically resolve them:
 // https://phenomnomnominal.github.io/betterer/docs/results-file/#merge
 //"
@@ -209,7 +209,7 @@ Array [
 
 exports[`betterer ci should work when a test is already complete 4`] = `
 "// BETTERER RESULTS V2.
-// 
+//
 // If this file contains merge conflicts, use \`betterer merge\` to automatically resolve them:
 // https://phenomnomnominal.github.io/betterer/docs/results-file/#merge
 //"

--- a/test/cli/__snapshots__/merge-contents.spec.ts.snap
+++ b/test/cli/__snapshots__/merge-contents.spec.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`betterer cli should merge the given contents 1`] = `
 "// BETTERER RESULTS V2.
-// 
+//
 // If this file contains merge conflicts, use \`betterer merge\` to automatically resolve them:
 // https://phenomnomnominal.github.io/betterer/docs/results-file/#merge
 //

--- a/test/cli/__snapshots__/merge-path.spec.ts.snap
+++ b/test/cli/__snapshots__/merge-path.spec.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`betterer cli should merge the results file 1`] = `
 "// BETTERER RESULTS V2.
-// 
+//
 // If this file contains merge conflicts, use \`betterer merge\` to automatically resolve them:
 // https://phenomnomnominal.github.io/betterer/docs/results-file/#merge
 //
@@ -18,7 +18,7 @@ exports[\`test\`] = {
 
 exports[`betterer cli should merge the results file 2`] = `
 "// BETTERER RESULTS V2.
-// 
+//
 // If this file contains merge conflicts, use \`betterer merge\` to automatically resolve them:
 // https://phenomnomnominal.github.io/betterer/docs/results-file/#merge
 //

--- a/test/cli/__snapshots__/precommit-specific-file.spec.ts.snap
+++ b/test/cli/__snapshots__/precommit-specific-file.spec.ts.snap
@@ -145,7 +145,7 @@ Checked 1 file! 🔍
 
 exports[`betterer precommit should test just the specified files 2`] = `
 "// BETTERER RESULTS V2.
-// 
+//
 // If this file contains merge conflicts, use \`betterer merge\` to automatically resolve them:
 // https://phenomnomnominal.github.io/betterer/docs/results-file/#merge
 //


### PR DESCRIPTION
This PR removes a trailing space in the header of the generated `.betterer.results` file.