### PR TITLE
docs(typescript): add noEmit true option to typescript text example

### DIFF
--- a/website/docs/typescript-test.md
+++ b/website/docs/typescript-test.md
@@ -16,7 +16,8 @@ import { typescript } from '@betterer/typescript';
 export default {
   'stricter compilation': () =>
     typescript('./tsconfig.json', {
-      strict: true
+      strict: true,
+      noEmit: true
     }).include('./src/**/*.ts')
 };
 ```


### PR DESCRIPTION
Prevent accidentally generating typescript files when following the docs.