### PR TITLE
feat(eslint): add the ability to add overrides to the extended eslint config

### DIFF
--- a/packages/eslint/src/eslint.ts
+++ b/packages/eslint/src/eslint.ts
@@ -1,6 +1,6 @@
 import type { Linter } from 'eslint';
 
-import type { BettererESLintRulesConfig } from './types.js';
+import type { BettererESLintOverridesConfig, BettererESLintRulesConfig } from './types.js';
 
 import { BettererFileTest } from '@betterer/betterer';
 import { BettererError } from '@betterer/errors';
@@ -37,7 +37,7 @@ import { ESLint } from 'eslint';
  * @throws {@link @betterer/errors#BettererError | `BettererError` }
  * Will throw if the user doesn't pass `rules`.
  */
-export function eslint(rules: BettererESLintRulesConfig): BettererFileTest {
+export function eslint(rules: BettererESLintRulesConfig, overrides?: BettererESLintOverridesConfig): BettererFileTest {
   if (!rules) {
     throw new BettererError(
       "for `@betterer/eslint` to work, you need to provide rule options, e.g. `{ 'no-debugger': 'error' }`. ❌"
@@ -64,7 +64,7 @@ export function eslint(rules: BettererESLintRulesConfig): BettererFileTest {
         const finalRules = { ...disabledRules, ...rules };
 
         const runner = new ESLint({
-          overrideConfig: { rules: finalRules },
+          overrideConfig: { rules: finalRules, overrides },
           useEslintrc: true,
           cwd: baseDirectory
         });

--- a/packages/eslint/src/types.ts
+++ b/packages/eslint/src/types.ts
@@ -8,3 +8,9 @@ import type { Linter } from 'eslint';
  * or {@link https://eslint.org/docs/user-guide/configuring/rules#configuring-rules | `RuleLevelAndOptions`}.
  */
 export type BettererESLintRulesConfig = Record<string, Linter.RuleLevel | Linter.RuleLevelAndOptions>;
+
+/**
+ * @public The {@link @betterer/eslint#eslint | `eslint`} test factory optionally takes a list of
+ * overrides used for specific filetypes and allowing for `parserOptions` configuration.
+ */
+export type BettererESLintOverridesConfig = Linter.ConfigOverride[];


### PR DESCRIPTION
This adds an optional parameter to the configuration passed to the ESLint test factory which should allow overrides to be passed into eslint.

Fixes: #1012