### PR TITLE
docs(betterer 📚): suggest a post-rewrite hook in the workflow docs

### DIFF
--- a/website/docs/workflow.md
+++ b/website/docs/workflow.md
@@ -10,6 +10,8 @@ There is not a perfect "one-size-fits-all" workflow for all teams, but here's a 
 
 - You should run **Betterer** in Pre-commit mode ([`betterer precommit`](./running-betterer#pre-commit-mode)) as a pre-commit hook - perhaps using [husky](https://typicode.github.io/husky) and [lint-staged](https://github.com/okonet/lint-staged).
 
+  - Pre-commit mode can also be useful as a post-rewrite hook to detect drift in the results file after a rebase.
+
 - You should run **Betterer** as part of a build pipeline along with other static analysis tools and tests.
 
 - You should run **Betterer** in CI mode ([`betterer ci`](./running-betterer#ci-mode-run-your-tests-and-throw-on-changes)) when running on a build server. When **Betterer** runs in CI mode, it will throw an error when the tests results do not exactly match whatever is in the results file. This ensures that the [results file](./results-file) accurately reflects the state of the codebase.


### PR DESCRIPTION
Related to #1184. 

In PR #1185 I've tried to make the CLI output clearer in the case where files have changed but test results have not.

This PR tries to get at the root cause. In my experience, when this happens, it's almost always because someone rebased their feature branch, pulling in new changes, and then pushed without re-running betterer. They may even have resolved merge conflicts in the results file while rebasing, but really what you need to do is run betterer again after the rebase has finished to make sure it's totally up to date.

I've been able to accomplish that with a post-rewrite hook in my codebase. This PR adds a line to the docs to suggest that as part of the betterer workflow.

Here's what it looks like in the docs site running locally on my laptop:

![Screenshot 2024-02-17 at 1 05 05 pm](https://github.com/phenomnomnominal/betterer/assets/1930451/d1a400e7-2f4c-4170-a83d-19d52a280aac)

To complete the picture, this is the post-rewrite hook that I've created in my codebase:

```sh
#!/usr/bin/env sh
. "$(dirname -- "$0")/_/husky.sh"

yarn betterer precommit

resultsChanged="$(git diff --staged .betterer.results)"

RED='\033[0;31m'
YLW='\033[1;33m'
NC='\033[0m' # No Color

if [[ -n $resultsChanged ]]
then
  echo
  echo "${RED}The ${YLW}.betterer.results${RED} file has changed after your rebase.${NC}"
  echo "${RED}You need to include these changes in a commit.${NC}"
  echo "${RED}Either create a new commit, or amend them onto your most recent commit.${NC}"
  echo
  exit 1
fi
```

When it fails it looks like this:

![image](https://github.com/phenomnomnominal/betterer/assets/1930451/4666d587-bc6b-47b1-a530-5dd64fd39d55)
