### PR TITLE
[ESLint] Support for extending of configuration files

### DIFF
--- a/goldens/api/eslint.api.md
+++ b/goldens/api/eslint.api.md
@@ -8,7 +8,9 @@ import { BettererFileTest } from '@betterer/betterer';
 import type { Linter } from 'eslint';
 
 // @public
-export type BettererESLintRulesConfig = Record<string, Linter.RuleLevel | Linter.RuleLevelAndOptions>;
+export type BettererESLintRulesConfig = Record<string, Linter.RuleLevel | Linter.RuleLevelAndOptions> | {
+    extends?: string | [string];
+};
 
 // @public
 export function eslint(rules: BettererESLintRulesConfig): BettererFileTest;

--- a/packages/eslint/src/eslint.ts
+++ b/packages/eslint/src/eslint.ts
@@ -57,11 +57,11 @@ export function eslint(rules: BettererESLintRulesConfig): BettererFileTest {
         const linterOptions = (await cli.calculateConfigForFile(filePath)) as Linter.Config;
 
         // Explicitly disable all other configured rules:
-        const disabledRules: BettererESLintRulesConfig = {};
+        const disabledRules: Linter.Config['rules'] = {};
         Object.keys(linterOptions.rules || {}).forEach((ruleName) => {
           disabledRules[ruleName] = 'off';
         });
-        const finalRules = { ...disabledRules, ...rules };
+        const { extends: _, ...finalRules } = { ...disabledRules, ...rules };
 
         const runner = new ESLint({
           overrideConfig: { rules: finalRules },

--- a/packages/eslint/src/types.ts
+++ b/packages/eslint/src/types.ts
@@ -7,4 +7,8 @@ import type { Linter } from 'eslint';
  * The configuration options are defined by each rule, but will be either a {@link https://eslint.org/docs/user-guide/configuring/rules#configuring-rules | `RuleLevel` }
  * or {@link https://eslint.org/docs/user-guide/configuring/rules#configuring-rules | `RuleLevelAndOptions`}.
  */
-export type BettererESLintRulesConfig = Record<string, Linter.RuleLevel | Linter.RuleLevelAndOptions>;
+export type BettererESLintRulesConfig =
+  | Record<string, Linter.RuleLevel | Linter.RuleLevelAndOptions>
+  | {
+      extends?: string | [string];
+    };


### PR DESCRIPTION
The @betterer/eslint-package should support the ["extends" property](https://eslint.org/docs/latest/use/configure/configuration-files#extending-configuration-files).

```
import { eslint } from '@betterer/eslint';

export default {
  'eslint recommendation': () => eslint({ extends: "eslint:recommended" }).include('./src/**/*.ts')
};
```