### PR TITLE
feature(angular ✨): report all angular diagnostics

### DIFF
--- a/packages/angular/src/angular.ts
+++ b/packages/angular/src/angular.ts
@@ -1,4 +1,4 @@
-import type { CompilerOptions } from '@angular/compiler-cli';
+import type { CompilerOptions, Program } from '@angular/compiler-cli';
 import type { DiagnosticWithLocation } from 'typescript';
 
 import { performCompilation, readConfiguration } from '@angular/compiler-cli';
@@ -54,7 +54,15 @@ export function angular(configFilePath: string, extraCompilerOptions: CompilerOp
 
     const { diagnostics } = performCompilation({
       rootNames,
-      options
+      options,
+      gatherDiagnostics: (program: Program) => [
+        ...program.getNgOptionDiagnostics(),
+        ...program.getNgSemanticDiagnostics(),
+        ...program.getNgStructuralDiagnostics(),
+        ...program.getTsOptionDiagnostics(),
+        ...program.getTsSemanticDiagnostics(),
+        ...program.getTsSyntacticDiagnostics(),
+      ]
     });
 
     diagnostics.forEach((diagnostic) => {


### PR DESCRIPTION
In a large code base with 19'000 issues Angular tests are not reporting .html errors even when the option `strictTemplates` is passed.

This is because Angular [defaultGatherDiagnostics](https://github.com/angular/angular/blob/main/packages/compiler-cli/src/perform_compile.ts#L328)  doesn't continue gathering diagnostics if some diagnostic checks fail.

This PR is a start for a discussion on how we want to introduce the changes, without breaking behavior.
So far this is a breaking change as now all errors will be reported.

But we could solve this for instance via a configuration and switch between default behavior and a report all at once behavior.
Other ideas are welcome.