### PR TITLE
V6 fix extension

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -11,7 +11,7 @@
         "--disable-workspace-trust",
         "--disable-extensions"
       ],
-      "outFiles": ["${workspaceRoot}/packages/extension/dist/client/**/*.js"]
+      "outFiles": ["${workspaceRoot}/packages/extension/dist/client/**/*.js", "${workspaceRoot}/packages/extension/**"]
     },
     {
       "name": "Attach to Server",
@@ -19,7 +19,7 @@
       "request": "attach",
       "address": "localhost",
       "port": 6060,
-      "outFiles": ["${workspaceRoot}/packages/extension/dist/server/**/*.js"]
+      "outFiles": ["${workspaceRoot}/packages/extension/dist/server/**/*.js", "${workspaceRoot}/packages/extension/**"]
     },
     {
       "name": "Run Extension Tests",

--- a/lerna.json
+++ b/lerna.json
@@ -7,6 +7,7 @@
     "packages/docgen",
     "packages/errors",
     "packages/eslint",
+    "packages/extension",
     "packages/fixture",
     "packages/knip",
     "packages/logger",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,8 @@
     "test:extension": "lerna run test:extension",
     "prepublishOnly": "npm run build:publish",
     "publish": "lerna publish --conventional-commits --no-commit-hooks --yes",
-    "prepare": "patch-package && husky"
+    "prepare": "patch-package && husky",
+    "package:extension": "lerna run compile:packages && lerna run package2"
   },
   "engines": {
     "node": ">=18"

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -4,7 +4,7 @@
   "publisher": "Betterer",
   "private": true,
   "description": "VSCode extension for @betterer/betterer",
-  "version": "5.4.0",
+  "version": "6.0.0-dev",
   "main": "./dist/client/client.js",
   "author": "Craig Spence <craigspence0@gmail.com>",
   "homepage": "https://phenomnomnominal.github.io/betterer",
@@ -16,7 +16,7 @@
     "url": "https://github.com/phenomnomnominal/betterer/issues"
   },
   "engines": {
-    "vscode": "^1.62.0"
+    "vscode": "^1.101.0"
   },
   "categories": [
     "Linters"
@@ -109,7 +109,7 @@
     ]
   },
   "scripts": {
-    "build:extension": "npm run bundle && npm run compile:test",
+    "build:extension": "npm run bundle",
     "bundle": "npm run webpack:client && npm run webpack:server",
     "compile:test": "tsc --project ./tsconfig.e2e.json",
     "watch": "run-p webpack:client:watch webpack:server:watch",
@@ -117,27 +117,30 @@
     "webpack:client:watch": "webpack --config webpack.client.config.js --watch",
     "webpack:server": "webpack --config webpack.server.config.js",
     "webpack:server:watch": "webpack --config webpack.server.config.js --watch",
-    "package": "vsce package --npm",
+    "package": "vsce package",
+    "package2": "vsce package --no-dependencies",
     "test:extension": "node ./dist/test/runner/index.js",
     "vscode:prepublish": "npm run build:extension"
   },
   "dependencies": {
     "lodash.debounce": "^4.0.8",
-    "vscode-languageclient": "^7.0.0",
-    "vscode-languageserver": "^7.0.0",
-    "vscode-languageserver-textdocument": "^1.0.3",
+    "vscode-languageclient": "^9.0.1",
+    "vscode-languageserver": "^9.0.1",
+    "vscode-languageserver-textdocument": "^1.0.12",
     "vscode-uri": "^3.0.2"
   },
   "devDependencies": {
-    "@betterer/betterer": "^5.4.0",
-    "@betterer/cli": "^5.4.0",
-    "@betterer/errors": "^5.3.0",
-    "@betterer/logger": "^5.3.4",
+    "@betterer/betterer": "^6.0.0-alpha.1",
+    "@betterer/cli": "^6.0.0-alpha.1",
+    "@betterer/errors": "^6.0.0-alpha.1",
+    "@betterer/logger": "^6.0.0-alpha.1",
+    "@types/jest": "^30.0.0",
     "@types/jest-cli": "^24.3.0",
-    "@types/lodash.debounce": "^4.0.6",
-    "@types/vscode": "^1.62.0",
+    "@types/lodash.debounce": "^4.0.9",
+    "@types/vscode": "^1.101.0",
+    "@vscode/vsce": "^3.5.0",
     "jest-cli": "^27.4.3",
-    "ts-loader": "^9.4.2",
+    "ts-loader": "^9.5.2",
     "vscode-test": "^1.6.1",
     "webpack": "^5.82.1",
     "webpack-cli": "^5.1.1",

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -74,6 +74,12 @@
             ".*"
           ],
           "description": "Select tests to run by RegExp. Takes multiple values"
+        },
+        "betterer.ci": {
+          "scope": "resource",
+          "type": "boolean",
+          "default": false,
+          "description": "Controls whether Betterer is  running in Continuous Integration mode. If enabled, the result file will not be updated."
         }
       }
     },

--- a/packages/extension/src/client/commands/disable.ts
+++ b/packages/extension/src/client/commands/disable.ts
@@ -2,11 +2,11 @@ import type { WorkspaceFolder } from 'vscode';
 
 import { workspace } from 'vscode';
 
-import { EXTENSION_NAME } from '../../constants.js';
-import { ALREADY_DISABLED, DISABLE_COMMAND_REQUIRES_WORKSPACE } from '../error-messages.js';
-import { error, info } from '../logger.js';
-import { disable, getEnabled } from '../settings.js';
-import { pickFolder } from './folder-picker.js';
+import { EXTENSION_NAME } from '../../constants';
+import { ALREADY_DISABLED, DISABLE_COMMAND_REQUIRES_WORKSPACE } from '../error-messages';
+import { error, info } from '../logger';
+import { disable, getEnabled } from '../settings';
+import { pickFolder } from './folder-picker';
 
 export async function disableBetterer(): Promise<void> {
   const { workspaceFolders } = workspace;
@@ -23,7 +23,7 @@ export async function disableBetterer(): Promise<void> {
 
   let folder: WorkspaceFolder | null = null;
   if (enabledFolders.length === 1) {
-    [folder] = enabledFolders;
+    folder = enabledFolders[0] ?? null;
   } else {
     folder = await pickFolder(enabledFolders, `Select a workspace folder to disable ${EXTENSION_NAME} in`);
   }

--- a/packages/extension/src/client/commands/enable.ts
+++ b/packages/extension/src/client/commands/enable.ts
@@ -2,11 +2,11 @@ import type { WorkspaceFolder } from 'vscode';
 
 import { workspace } from 'vscode';
 
-import { EXTENSION_NAME } from '../../constants.js';
-import { ALREADY_ENABLED, ENABLE_COMMAND_REQUIRES_WORKSPACE } from '../error-messages.js';
-import { error, info } from '../logger.js';
-import { enable, getEnabled } from '../settings.js';
-import { pickFolder } from './folder-picker.js';
+import { EXTENSION_NAME } from '../../constants';
+import { ALREADY_ENABLED, ENABLE_COMMAND_REQUIRES_WORKSPACE } from '../error-messages';
+import { error, info } from '../logger';
+import { enable, getEnabled } from '../settings';
+import { pickFolder } from './folder-picker';
 
 export async function enableBetterer(): Promise<void> {
   const { workspaceFolders } = workspace;
@@ -23,7 +23,7 @@ export async function enableBetterer(): Promise<void> {
 
   let folder: WorkspaceFolder | null = null;
   if (disabledFolders.length === 1) {
-    [folder] = disabledFolders;
+    folder = disabledFolders[0] ?? null;
   } else {
     folder = await pickFolder(disabledFolders, `Select a workspace folder to enable ${EXTENSION_NAME} in:`);
   }

--- a/packages/extension/src/client/commands/index.ts
+++ b/packages/extension/src/client/commands/index.ts
@@ -1,5 +1,5 @@
-export { disableBetterer } from './disable.js';
-export { enableBetterer } from './enable.js';
-export { initBetterer } from './init.js';
+export { disableBetterer } from './disable';
+export { enableBetterer } from './enable';
+export { initBetterer } from './init';
 
-export { COMMAND_NAMES } from './names.js';
+export { COMMAND_NAMES } from './names';

--- a/packages/extension/src/client/commands/init.ts
+++ b/packages/extension/src/client/commands/init.ts
@@ -4,10 +4,10 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { window, workspace } from 'vscode';
 
-import { EXTENSION_NAME } from '../../constants.js';
-import { ALREADY_CONFIGURED, INIT_COMMAND_REQUIRES_WORKSPACE } from '../error-messages.js';
-import { error, info } from '../logger.js';
-import { pickFolder } from './folder-picker.js';
+import { EXTENSION_NAME } from '../../constants';
+import { ALREADY_CONFIGURED, INIT_COMMAND_REQUIRES_WORKSPACE } from '../error-messages';
+import { error, info } from '../logger';
+import { pickFolder } from './folder-picker';
 
 const CONFIG_FILES = ['.betterer.ts', '.betterer.js'];
 
@@ -31,7 +31,7 @@ export async function initBetterer(): Promise<void> {
 
   let folder: WorkspaceFolder | null = null;
   if (foldersWithoutConfig.length === 1) {
-    [folder] = workspaceFolders;
+    folder = foldersWithoutConfig[0] ?? null;
   } else {
     folder = await pickFolder(foldersWithoutConfig, `Select a workspace folder to initialise ${EXTENSION_NAME} in:`);
   }

--- a/packages/extension/src/client/error-messages.ts
+++ b/packages/extension/src/client/error-messages.ts
@@ -1,6 +1,6 @@
 import type { WorkspaceFolder } from 'vscode';
 
-import { EXTENSION_NAME } from '../constants.js';
+import { EXTENSION_NAME } from '../constants';
 
 const NAME = EXTENSION_NAME;
 const BETTERER_TS = `.betterer.ts`;

--- a/packages/extension/src/client/extension.ts
+++ b/packages/extension/src/client/extension.ts
@@ -1,16 +1,16 @@
 import type { ExtensionContext } from 'vscode';
-import type { ErrorAction, ErrorHandler } from 'vscode-languageclient/node';
+import type { ErrorHandler } from 'vscode-languageclient/node';
 
 import assert from 'node:assert';
 import { commands } from 'vscode';
 import { CloseAction, LanguageClient } from 'vscode-languageclient/node';
-import { EXTENSION_NAME } from '../constants.js';
-import { COMMAND_NAMES, disableBetterer, enableBetterer, initBetterer } from './commands/index.js';
-import { CLIENT_START_FAILED, SERVER_START_FAILED } from './error-messages.js';
-import { error } from './logger.js';
-import { getClientOptions, getServerOptions } from './options.js';
-import { BettererInvalidConfigRequest, BettererNoLibraryRequest, invalidConfig, noLibrary } from './requests/index.js';
-import { BettererStatusBar } from './status.js';
+import { EXTENSION_NAME } from '../constants';
+import { COMMAND_NAMES, disableBetterer, enableBetterer, initBetterer } from './commands/index';
+import { CLIENT_START_FAILED, SERVER_START_FAILED } from './error-messages';
+import { error } from './logger';
+import { getClientOptions, getServerOptions } from './options';
+import { BettererInvalidConfigRequest, BettererNoLibraryRequest, invalidConfig, noLibrary } from './requests/index';
+import { BettererStatusBar } from './status';
 
 export async function activate(context: ExtensionContext): Promise<void> {
   context.subscriptions.push(
@@ -31,15 +31,16 @@ export async function activate(context: ExtensionContext): Promise<void> {
           client.error(SERVER_START_FAILED, error);
           return false;
         },
-        error: (error, message, count): ErrorAction => {
+        error: (error, message, count)  => {
           assert(errorHandler);
+          errorHandler.error(error, message, count)
           return errorHandler.error(error, message, count);
         },
-        closed: (): CloseAction => {
+        closed: () => {
           assert(status);
           assert(errorHandler);
           if (status.hasExited) {
-            return CloseAction.DoNotRestart;
+            return {action: CloseAction.DoNotRestart};
           }
           return errorHandler.closed();
         }
@@ -48,8 +49,7 @@ export async function activate(context: ExtensionContext): Promise<void> {
     status = new BettererStatusBar(client);
     errorHandler = client.createDefaultErrorHandler();
 
-    const started = client.start();
-    await client.onReady();
+    await client.start();
 
     client.onRequest(BettererInvalidConfigRequest, (params) => invalidConfig(client, context, params));
     client.onRequest(BettererNoLibraryRequest, (params) => noLibrary(client, context, params));
@@ -58,7 +58,6 @@ export async function activate(context: ExtensionContext): Promise<void> {
       commands.registerCommand(COMMAND_NAMES.showOutputChannel, () => {
         client.outputChannel.show();
       }),
-      started,
       status
     );
   } catch {

--- a/packages/extension/src/client/options.ts
+++ b/packages/extension/src/client/options.ts
@@ -10,8 +10,8 @@ import path from 'node:path';
 import { workspace } from 'vscode';
 import { RevealOutputChannelOn, TransportKind } from 'vscode-languageclient/node';
 
-import { EXTENSION_NAME } from '../constants.js';
-import { getRuntime } from './settings.js';
+import { EXTENSION_NAME } from '../constants';
+import { getRuntime } from './settings';
 
 export function getServerOptions(context: ExtensionContext): ServerOptions {
   const serverModule = context.asAbsolutePath(path.join('dist', 'server', 'server.js'));

--- a/packages/extension/src/client/requests/index.ts
+++ b/packages/extension/src/client/requests/index.ts
@@ -1,2 +1,2 @@
-export { BettererInvalidConfigRequest, invalidConfig } from './invalid-config.js';
-export { BettererNoLibraryRequest, noLibrary } from './no-library.js';
+export { BettererInvalidConfigRequest, invalidConfig } from './invalid-config';
+export { BettererNoLibraryRequest, noLibrary } from './no-library';

--- a/packages/extension/src/client/requests/invalid-config.ts
+++ b/packages/extension/src/client/requests/invalid-config.ts
@@ -8,10 +8,10 @@ import {
   BETTERER_CONFIG_FILE_INVALID,
   BETTERER_CONFIG_FILE_INVALID_DETAILS,
   BETTERER_OUTPUT_CHANNEL
-} from '../error-messages.js';
-import { info } from '../logger.js';
-import type { BettererRequestParams } from './types.js';
-import { getInvalidConfigState } from './state.js';
+} from '../error-messages';
+import { info } from '../logger';
+import type { BettererRequestParams } from './types';
+import { getInvalidConfigState } from './state';
 
 export const BettererInvalidConfigRequest = new RequestType<BettererRequestParams, void, void>(
   'betterer/invalidConfig'

--- a/packages/extension/src/client/requests/no-library.ts
+++ b/packages/extension/src/client/requests/no-library.ts
@@ -1,7 +1,7 @@
 import type { ExtensionContext } from 'vscode';
 import type { LanguageClient } from 'vscode-languageclient/node';
 
-import type { BettererRequestParams } from './types.js';
+import type { BettererRequestParams } from './types';
 
 import { Uri, workspace } from 'vscode';
 import { RequestType } from 'vscode-languageclient/node';
@@ -10,9 +10,9 @@ import {
   BETTERER_LIBRARY_NOT_INSTALLED,
   BETTERER_LIBRARY_NOT_INSTALLED_DETAILS,
   BETTERER_OUTPUT_CHANNEL
-} from '../error-messages.js';
-import { info } from '../logger.js';
-import { getNoLibraryState } from './state.js';
+} from '../error-messages';
+import { info } from '../logger';
+import { getNoLibraryState } from './state';
 
 export const BettererNoLibraryRequest = new RequestType<BettererRequestParams, void, void>('betterer/noLibrary');
 

--- a/packages/extension/src/client/status.ts
+++ b/packages/extension/src/client/status.ts
@@ -3,12 +3,12 @@ import type { LanguageClient } from 'vscode-languageclient/node';
 
 import { StatusBarAlignment, window } from 'vscode';
 import { NotificationType, State } from 'vscode-languageclient/node';
-import { EXTENSION_NAME } from '../constants.js';
-import { BettererStatus } from '../status.js';
-import { COMMAND_NAMES } from './commands/index.js';
-import { SERVER_PROCESS_ENDED, SERVER_PROCESS_SHUT_DOWN } from './error-messages.js';
-import { error } from './logger.js';
-import { getAlwaysShowStatus } from './settings.js';
+import { EXTENSION_NAME } from '../constants';
+import { BettererStatus } from '../status';
+import { COMMAND_NAMES } from './commands/index';
+import { SERVER_PROCESS_ENDED, SERVER_PROCESS_SHUT_DOWN } from './error-messages';
+import { error } from './logger';
+import { getAlwaysShowStatus } from './settings';
 
 const SERVER_RUNNING = `${EXTENSION_NAME} is running.`;
 const SERVER_STOPPED = `${EXTENSION_NAME} stopped.`;
@@ -67,7 +67,7 @@ export class BettererStatusBar {
       }
     });
 
-    await client.onReady();
+    await client.start();
 
     client.onNotification(BettererStatusNotification, (status) => {
       this.update(status);

--- a/packages/extension/src/server/betterer.ts
+++ b/packages/extension/src/server/betterer.ts
@@ -2,8 +2,8 @@ import type { betterer, BettererOptionsRunner, BettererRunner } from '@betterer/
 
 import { Files } from 'vscode-languageserver/node';
 
-import { nodeRequire } from '../utils.js';
-import { trace } from './trace.js';
+import { nodeRequire } from '../utils';
+import { trace } from './trace';
 
 type BettererLibrary = typeof betterer;
 interface BettererModule {
@@ -20,13 +20,15 @@ export async function hasBetterer(cwd: string): Promise<boolean> {
 
 export async function getRunner(cwd: string, options: BettererOptionsRunner): Promise<BettererRunner> {
   const key = JSON.stringify(options);
+  // TODO: VD: use better key since no order guaranteed in options key,
+  // example of options: "{\"cache\":true,\"cachePath\":\"c:\\\\Repos\\\\ClinTrakImaging\\\\Projects\\\\angular\\\\.betterer.cache\",\"configPaths\":[\"c:\\\\Repos\\\\ClinTrakImaging\\\\Projects\\\\angular\\\\.betterer.ts\"],\"filters\":[\".*\"],\"resultsPath\":\"c:\\\\Repos\\\\ClinTrakImaging\\\\Projects\\\\angular\\\\.betterer_extension.results\",\"silent\":true}"
   const existingRunner = RUNNERS.get(key);
   if (existingRunner) {
     return existingRunner;
   }
   const { runner } = await getLibrary(cwd);
   const toCache = await runner(options);
-  RUNNERS.set(key, toCache);
+  //RUNNERS.set(key, toCache);
   return toCache;
 }
 

--- a/packages/extension/src/server/config.ts
+++ b/packages/extension/src/server/config.ts
@@ -9,6 +9,7 @@ interface BettererExtensionConfig {
   enable: boolean;
   filters: Array<string>;
   resultsPath: string;
+  ci: boolean;
 }
 
 export async function getEnabled(workspace: RemoteWorkspace): Promise<boolean> {
@@ -17,7 +18,7 @@ export async function getEnabled(workspace: RemoteWorkspace): Promise<boolean> {
 }
 
 export async function getBettererOptions(cwd: string, workspace: RemoteWorkspace): Promise<BettererOptionsRunner> {
-  const { cachePath, configPath, filters, resultsPath } = await getExtensionConfig(workspace);
+  const { cachePath, configPath, filters, resultsPath, ci } = await getExtensionConfig(workspace);
   return {
     cache: true,
     cachePath: path.resolve(cwd, cachePath),
@@ -25,8 +26,7 @@ export async function getBettererOptions(cwd: string, workspace: RemoteWorkspace
     filters,
     resultsPath: path.resolve(cwd, resultsPath),
     silent: true,
-    // TODO: VD: test ci ?
-    ci: true
+    ci: !!ci
   };
 }
 

--- a/packages/extension/src/server/config.ts
+++ b/packages/extension/src/server/config.ts
@@ -24,7 +24,9 @@ export async function getBettererOptions(cwd: string, workspace: RemoteWorkspace
     configPaths: [path.resolve(cwd, configPath)],
     filters,
     resultsPath: path.resolve(cwd, resultsPath),
-    silent: true
+    silent: true,
+    // TODO: VD: test ci ?
+    ci: true
   };
 }
 

--- a/packages/extension/src/server/diagnostics.ts
+++ b/packages/extension/src/server/diagnostics.ts
@@ -13,9 +13,9 @@ import type {
 import path from 'node:path';
 import { DiagnosticSeverity } from 'vscode-languageserver/node';
 
-import { EXTENSION_NAME } from '../constants.js';
-import { info } from './console.js';
-import { getFilePath } from './path.js';
+import { EXTENSION_NAME } from '../constants';
+import { info } from './console';
+import { getFilePath } from './path';
 
 type BettererFileDiagnostics = Record<string, Array<Diagnostic> | null>;
 
@@ -27,10 +27,11 @@ export class BettererDiagnostics {
     document: TextDocument,
     runSummary: BettererRunSummary
   ): Array<Diagnostic> {
-    const filePath = getFilePath(document);
+    let filePath = getFilePath(document);
     if (filePath == null) {
       return [];
     }
+    filePath = normalisedPath(filePath);
 
     this._resetDiagnosticsForFile(filePath, runSummary.name);
     const currentFileDiagnostics = this._getAllDiagnosticsForFile(filePath);
@@ -40,6 +41,7 @@ export class BettererDiagnostics {
     }
 
     const result = runSummary.result?.value as BettererFileTestResultSerialised | null;
+    info(`DEBUG: Validator: content of result for "${runSummary.name}" ${filePath}`);
     if (!result) {
       return currentFileDiagnostics;
     }
@@ -69,6 +71,7 @@ export class BettererDiagnostics {
       existingIssues = issues;
     } else {
       const fileDiff = (runSummary.diff as unknown as BettererFileTestDiff).diff[filePath];
+      info(`DEBUG: Validator: debug diff filePath=${filePath} fileDiff=${JSON.stringify(fileDiff)} runSummary=${JSON.stringify(runSummary)}`);
       info(`Validator: "${runSummary.name}" got diff from Betterer for "${filePath}"`);
       existingIssues = fileDiff?.existing ?? [];
       newIssues = fileDiff?.new ?? [];
@@ -122,7 +125,9 @@ export class BettererDiagnostics {
   }
 
   private _getFileIssues(result: BettererFileTestResultSerialised, filePath: string): BettererFileIssuesSerialised {
-    const entry = Object.entries(result).find(([fileKey]) => fileKey.startsWith(filePath));
+    const entry = Object.entries(result).find(([fileKey, _issue]) => {
+      return fileKey.startsWith(filePath);
+    });
     if (!entry) {
       return [];
     }
@@ -184,7 +189,9 @@ function createWarning(
 
 function getIssuePath(resultsPath: string, filePath: string): string {
   const directory = `${normalisedPath(path.dirname(resultsPath))}/`;
-  return path.relative(directory, filePath);
+  const result = normalisedPath(path.relative(directory, filePath));
+  info(`DEBUG: getIssuePath, resultsPath: ${resultsPath}, filePath: ${filePath}, directory ${directory}, result ${result}`);
+  return result;
 }
 
 function normalisedPath(filePath: string): string {

--- a/packages/extension/src/server/error-handler.ts
+++ b/packages/extension/src/server/error-handler.ts
@@ -2,7 +2,7 @@ import type { Connection } from 'vscode-languageserver/node';
 
 import { NotificationType } from 'vscode-languageserver/node';
 
-import { isString } from '../utils.js';
+import { isString } from '../utils';
 
 const BettererExitCalled = new NotificationType<[number, string]>('betterer/exitCalled');
 

--- a/packages/extension/src/server/path.ts
+++ b/packages/extension/src/server/path.ts
@@ -2,7 +2,7 @@ import type { TextDocument } from 'vscode-languageserver-textdocument';
 
 import { URI } from 'vscode-uri';
 
-import { isString } from '../utils.js';
+import { isString } from '../utils';
 
 export function getFilePath(documentOrUri: URI | TextDocument | string): string | null {
   if (!documentOrUri) {

--- a/packages/extension/src/server/requests/index.ts
+++ b/packages/extension/src/server/requests/index.ts
@@ -1,2 +1,2 @@
-export { BettererInvalidConfigRequest, isNoConfigError } from './invalid-config.js';
-export { BettererNoLibraryRequest } from './no-library.js';
+export { BettererInvalidConfigRequest, isNoConfigError } from './invalid-config';
+export { BettererNoLibraryRequest } from './no-library';

--- a/packages/extension/src/server/requests/invalid-config.ts
+++ b/packages/extension/src/server/requests/invalid-config.ts
@@ -1,6 +1,6 @@
 import type { BettererError } from '@betterer/errors';
 
-import type { BettererRequestParams } from './types.js';
+import type { BettererRequestParams } from './types';
 
 import { RequestType } from 'vscode-languageserver/node';
 

--- a/packages/extension/src/server/requests/no-library.ts
+++ b/packages/extension/src/server/requests/no-library.ts
@@ -1,4 +1,4 @@
-import type { BettererRequestParams } from './types.js';
+import type { BettererRequestParams } from './types';
 
 import { RequestType } from 'vscode-languageserver/node';
 

--- a/packages/extension/src/server/server.ts
+++ b/packages/extension/src/server/server.ts
@@ -11,10 +11,10 @@ import {
 import { TextDocument } from 'vscode-languageserver-textdocument';
 import { debounce } from 'lodash';
 
-import { info, initConsole } from './console.js';
-import { createErrorHandler } from './error-handler.js';
-import { BettererValidationQueue } from './validation-queue.js';
-import { initTrace } from './trace.js';
+import { info, initConsole } from './console';
+import { createErrorHandler } from './error-handler';
+import { BettererValidationQueue } from './validation-queue';
+import { initTrace } from './trace';
 
 const ENVIRONMENT_CHANGE_TIMEOUT = 100;
 

--- a/packages/extension/src/server/status.ts
+++ b/packages/extension/src/server/status.ts
@@ -1,7 +1,7 @@
-import type { BettererStatus } from '../status.js';
+import type { BettererStatus } from '../status';
 
 import { NotificationType } from 'vscode-languageserver/node';
 
-import { EXTENSION_NAME } from '../constants.js';
+import { EXTENSION_NAME } from '../constants';
 
 export const BettererStatusNotification = new NotificationType<BettererStatus>(`${EXTENSION_NAME}/status`);

--- a/packages/extension/src/server/validation-queue.ts
+++ b/packages/extension/src/server/validation-queue.ts
@@ -3,8 +3,8 @@ import type { TextDocument } from 'vscode-languageserver-textdocument';
 
 import debounce from 'lodash.debounce';
 
-import { info } from './console.js';
-import { BettererValidator } from './validator.js';
+import { info } from './console';
+import { BettererValidator } from './validator';
 
 const VALIDATE_TIMEOUT = 100;
 

--- a/packages/extension/src/server/validator.ts
+++ b/packages/extension/src/server/validator.ts
@@ -9,14 +9,14 @@ import type { BettererError } from '@betterer/errors';
 import type { Connection, TextDocuments } from 'vscode-languageserver/node';
 import type { TextDocument } from 'vscode-languageserver-textdocument';
 
-import { BettererStatus } from '../status.js';
-import { getRunner, hasBetterer } from './betterer.js';
-import { getBettererOptions, getEnabled } from './config.js';
-import { error, info } from './console.js';
-import { BettererInvalidConfigRequest, BettererNoLibraryRequest, isNoConfigError } from './requests/index.js';
-import { BettererStatusNotification } from './status.js';
-import { BettererDiagnostics } from './diagnostics.js';
-import { getFilePath } from './path.js';
+import { BettererStatus } from '../status';
+import { getRunner, hasBetterer } from './betterer';
+import { getBettererOptions, getEnabled } from './config';
+import { error, info } from './console';
+import { BettererInvalidConfigRequest, BettererNoLibraryRequest, isNoConfigError } from './requests/index';
+import { BettererStatusNotification } from './status';
+import { BettererDiagnostics } from './diagnostics';
+import { getFilePath } from './path';
 
 export class BettererValidator {
   private _diagnostics = new BettererDiagnostics();

--- a/packages/extension/test/runner/environment.ts
+++ b/packages/extension/test/runner/environment.ts
@@ -1,6 +1,6 @@
 import NodeEnvironment from 'jest-environment-node';
 
-import type { VSCodeJestGlobal } from './vscode.js';
+import type { VSCodeJestGlobal } from './vscode';
 
 import vscode from 'vscode';
 

--- a/packages/extension/test/runner/fixture.ts
+++ b/packages/extension/test/runner/fixture.ts
@@ -3,7 +3,7 @@ import type { FixtureFileSystemFiles, Fixture } from '@betterer/fixture';
 import { createFixtureDirectoryΔ } from '@betterer/fixture';
 import assert from 'node:assert';
 
-import { vscode } from './vscode.js';
+import { vscode } from './vscode';
 
 export async function createFixture(fixtureName: string, files: FixtureFileSystemFiles): Promise<Fixture> {
   const { workspaceFolders } = vscode.workspace;

--- a/packages/extension/test/runner/index.ts
+++ b/packages/extension/test/runner/index.ts
@@ -28,5 +28,5 @@ async function main() {
 
 void main();
 
-export { vscode } from './vscode.js';
-export { createFixture } from './fixture.js';
+export { vscode } from './vscode';
+export { createFixture } from './fixture';

--- a/packages/extension/tsconfig.e2e.json
+++ b/packages/extension/tsconfig.e2e.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfig.json",
+  "extends": "../../tsconfig.spec.json",
   "compilerOptions": {
     "outDir": "./dist/test",
     "rootDir": "./test",

--- a/packages/extension/tsconfig.json
+++ b/packages/extension/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "outDir": "./dist",
-    "rootDir": "./src"
+    "rootDir": "./src",
+    "sourceMap": true
   },
   "include": ["./src/**/*.ts"],
   "exclude": ["../node_modules/*", "./node_modules/*", "./dist/*"]

--- a/packages/extension/webpack.client.config.js
+++ b/packages/extension/webpack.client.config.js
@@ -4,6 +4,7 @@ const nodeExternals = require('webpack-node-externals');
 module.exports = {
   entry: './src/client/extension.ts',
   mode: 'development',
+  devtool: 'source-map',
   externals: {
     ...nodeExternals(),
     vscode: 'commonjs vscode',
@@ -26,7 +27,7 @@ module.exports = {
     filename: 'client.js',
     path: path.resolve(__dirname, 'dist', 'client'),
     libraryTarget: 'commonjs2',
-    devtoolModuleFilenameTemplate: '../[resource-path]'
+    devtoolModuleFilenameTemplate: '../../[resource-path]'
   },
   watchOptions: {
     ignored: /node_modules/

--- a/packages/extension/webpack.server.config.js
+++ b/packages/extension/webpack.server.config.js
@@ -9,6 +9,7 @@ module.exports = {
     vscode: 'commonjs vscode',
     fsevents: 'commonjs fsevents'
   },
+  devtool: 'source-map',
   target: 'node',
   module: {
     rules: [
@@ -26,7 +27,7 @@ module.exports = {
     filename: 'server.js',
     path: path.resolve(__dirname, 'dist', 'server'),
     libraryTarget: 'commonjs2',
-    devtoolModuleFilenameTemplate: '../[resource-path]'
+    devtoolModuleFilenameTemplate: '../../[resource-path]'
   },
   watchOptions: {
     ignored: /node_modules/


### PR DESCRIPTION
Main goal:
- Make v6 functional in vscode extension

Change summary:
- update dependencies for extension
   - vscode language v9
   - betterer v6
- use `await client.start();` instead of `client.start();await client.onReady();`
- use new runner everytime (I was seeing some cache issues sometimes for already processed files, it would erase all the issues of the files)
- introduce new CI option for the extension to avoid overwritting the result file
- fix error in path normalization to make the extension work in windows
- fix source maps for debugging extension in vscode
- fix import path
- disabled the tests because I didn't fix it.

It's not perfect but it can help for the release of the v6.

