### PR TITLE
fix(betterer 🐛): don't reinitialize an existing git repo (corrupts shared config in worktrees)

### DIFF
--- a/packages/betterer/src/fs/git.ts
+++ b/packages/betterer/src/fs/git.ts
@@ -105,11 +105,6 @@ export class BettererGitΩ implements BettererVersionControl {
   }
 
   private async _init(git: SimpleGit): Promise<void> {
-    // `_findGitRoot` has already established that we are inside a git repository, so there is no
-    // need to initialise one. Re-running `git init` is not only redundant, it is dangerous: in a
-    // linked worktree (where `<worktree>/.git` is a gitfile pointing into a shared common git dir)
-    // it reinitialises against the *common* git dir and can rewrite shared config, flipping
-    // `core.bare` and breaking every worktree on the repo:
     if (await git.checkIsRepo()) {
       return;
     }

--- a/packages/betterer/src/fs/git.ts
+++ b/packages/betterer/src/fs/git.ts
@@ -105,12 +105,22 @@ export class BettererGitΩ implements BettererVersionControl {
   }
 
   private async _init(git: SimpleGit): Promise<void> {
+    // `_findGitRoot` has already established that we are inside a git repository, so there is no
+    // need to initialise one. Re-running `git init` is not only redundant, it is dangerous: in a
+    // linked worktree (where `<worktree>/.git` is a gitfile pointing into a shared common git dir)
+    // it reinitialises against the *common* git dir and can rewrite shared config, flipping
+    // `core.bare` and breaking every worktree on the repo:
+    if (await git.checkIsRepo()) {
+      return;
+    }
+
     const retries = 3;
     for (let i = 0; i < retries; i++) {
       try {
         await git.init();
+        return;
       } catch (error) {
-        if (i >= retries) {
+        if (i === retries - 1) {
           throw error;
         }
       }

--- a/test/worktree.spec.ts
+++ b/test/worktree.spec.ts
@@ -1,72 +1,50 @@
 // eslint-disable-next-line require-extensions/require-extensions -- tests not ESM ready yet
 import { createFixture } from './fixture';
 
-import { exec as execΩ } from 'node:child_process';
-import { promises as fs } from 'node:fs';
-import path from 'node:path';
-import { promisify } from 'node:util';
-
-const exec = promisify(execΩ);
+import { simpleGit } from 'simple-git';
 
 describe('betterer', () => {
   it('should not reinitialise the repository when run inside a git worktree', async () => {
     const { betterer } = await import('@betterer/betterer');
 
-    // The fixture directory is our scratch space. Inside it we build the popular "bare repo +
-    // linked worktree" layout, where the worktree's `.git` is a gitfile pointing into a shared
-    // common (bare) git dir. Running `git init` from inside the worktree reinitialises against
-    // that *shared* dir and flips its `core.bare` to `false`, breaking every worktree on the repo.
-    const { paths, cleanup } = await createFixture('worktree', {});
+    const { resolve, cleanup } = await createFixture('worktree', {
+      'source/.betterer.js': `
+const { regexp } = require('@betterer/regexp');
 
-    const root = paths.cwd;
-    const sourcePath = path.posix.join(root, 'source');
-    const barePath = path.posix.join(root, 'repo.git');
-    const worktreePath = path.posix.join(root, 'worktree');
+module.exports = {
+  test: () => regexp(/(\\/\\/\\s*HACK)/i).include('./src/**/*.ts')
+};
+      `,
+      'source/src/index.ts': `// HACK:`
+    });
 
-    async function git(cwd: string, command: string): Promise<string> {
-      const { stdout } = await exec(`git ${command}`, { cwd });
-      return stdout.trim();
-    }
+    const sourcePath = resolve('source');
+    const barePath = resolve('repo.git');
+    const worktreePath = resolve('worktree');
 
-    // 1. Create a source repository with a Betterer config and a file to lint:
-    await fs.mkdir(path.posix.join(sourcePath, 'src'), { recursive: true });
-    await fs.writeFile(
-      path.posix.join(sourcePath, '.betterer.js'),
-      [
-        `const { regexp } = require('@betterer/regexp');`,
-        ``,
-        `module.exports = {`,
-        `  test: () => regexp(/(\\/\\/\\s*HACK)/i).include('./src/**/*.ts')`,
-        `};`
-      ].join('\n')
-    );
-    await fs.writeFile(path.posix.join(sourcePath, 'src', 'index.ts'), `// HACK:`);
-    await git(sourcePath, 'init -q');
-    await git(sourcePath, 'config user.email test@betterer.dev');
-    await git(sourcePath, 'config user.name "Betterer Test"');
-    await git(sourcePath, 'add -A');
-    await git(sourcePath, 'commit -qm "init"');
-    const branch = await git(sourcePath, 'symbolic-ref --short HEAD');
+    const source = simpleGit(sourcePath);
+    await source.init();
+    await source.addConfig('user.email', 'test@betterer.dev');
+    await source.addConfig('user.name', 'Betterer Test');
+    await source.add('.');
+    await source.commit('init');
+    const branch = (await source.revparse(['--abbrev-ref', 'HEAD'])).trim();
 
-    // 2. Create a bare clone to act as the shared common git dir:
-    await git(root, `clone -q --bare "${sourcePath}" "${barePath}"`);
+    await simpleGit(resolve('.')).clone(sourcePath, barePath, ['--bare']);
 
-    // 3. Add a linked worktree off the bare repo:
-    await git(barePath, `worktree add -q "${worktreePath}" ${branch}`);
+    const bare = simpleGit(barePath);
+    await bare.raw('worktree', 'add', worktreePath, branch);
 
-    // The shared common dir is bare to begin with:
-    expect(await git(barePath, 'config --get core.bare')).toBe('true');
+    expect((await bare.raw('config', '--get', 'core.bare')).trim()).toBe('true');
 
-    // 4. Run Betterer inside the worktree:
     await betterer({
       cwd: worktreePath,
-      configPaths: [path.posix.join(worktreePath, '.betterer.js')],
-      resultsPath: path.posix.join(worktreePath, '.betterer.results'),
+      configPaths: [resolve('worktree/.betterer.js')],
+      resultsPath: resolve('worktree/.betterer.results'),
       workers: false
     });
 
-    // 5. The shared common-dir config must be untouched:
-    expect(await git(barePath, 'config --get core.bare')).toBe('true');
+    expect((await bare.raw('config', '--get', 'core.bare')).trim()).toBe('true');
 
     await cleanup();
   });

--- a/test/worktree.spec.ts
+++ b/test/worktree.spec.ts
@@ -1,0 +1,73 @@
+// eslint-disable-next-line require-extensions/require-extensions -- tests not ESM ready yet
+import { createFixture } from './fixture';
+
+import { exec as execΩ } from 'node:child_process';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import { promisify } from 'node:util';
+
+const exec = promisify(execΩ);
+
+describe('betterer', () => {
+  it('should not reinitialise the repository when run inside a git worktree', async () => {
+    const { betterer } = await import('@betterer/betterer');
+
+    // The fixture directory is our scratch space. Inside it we build the popular "bare repo +
+    // linked worktree" layout, where the worktree's `.git` is a gitfile pointing into a shared
+    // common (bare) git dir. Running `git init` from inside the worktree reinitialises against
+    // that *shared* dir and flips its `core.bare` to `false`, breaking every worktree on the repo.
+    const { paths, cleanup } = await createFixture('worktree', {});
+
+    const root = paths.cwd;
+    const sourcePath = path.posix.join(root, 'source');
+    const barePath = path.posix.join(root, 'repo.git');
+    const worktreePath = path.posix.join(root, 'worktree');
+
+    async function git(cwd: string, command: string): Promise<string> {
+      const { stdout } = await exec(`git ${command}`, { cwd });
+      return stdout.trim();
+    }
+
+    // 1. Create a source repository with a Betterer config and a file to lint:
+    await fs.mkdir(path.posix.join(sourcePath, 'src'), { recursive: true });
+    await fs.writeFile(
+      path.posix.join(sourcePath, '.betterer.js'),
+      [
+        `const { regexp } = require('@betterer/regexp');`,
+        ``,
+        `module.exports = {`,
+        `  test: () => regexp(/(\\/\\/\\s*HACK)/i).include('./src/**/*.ts')`,
+        `};`
+      ].join('\n')
+    );
+    await fs.writeFile(path.posix.join(sourcePath, 'src', 'index.ts'), `// HACK:`);
+    await git(sourcePath, 'init -q');
+    await git(sourcePath, 'config user.email test@betterer.dev');
+    await git(sourcePath, 'config user.name "Betterer Test"');
+    await git(sourcePath, 'add -A');
+    await git(sourcePath, 'commit -qm "init"');
+    const branch = await git(sourcePath, 'symbolic-ref --short HEAD');
+
+    // 2. Create a bare clone to act as the shared common git dir:
+    await git(root, `clone -q --bare "${sourcePath}" "${barePath}"`);
+
+    // 3. Add a linked worktree off the bare repo:
+    await git(barePath, `worktree add -q "${worktreePath}" ${branch}`);
+
+    // The shared common dir is bare to begin with:
+    expect(await git(barePath, 'config --get core.bare')).toBe('true');
+
+    // 4. Run Betterer inside the worktree:
+    await betterer({
+      cwd: worktreePath,
+      configPaths: [path.posix.join(worktreePath, '.betterer.js')],
+      resultsPath: path.posix.join(worktreePath, '.betterer.results'),
+      workers: false
+    });
+
+    // 5. The shared common-dir config must be untouched:
+    expect(await git(barePath, 'config --get core.bare')).toBe('true');
+
+    await cleanup();
+  });
+});


### PR DESCRIPTION
### What

`BettererGitΩ._init()` ran `git init` on **every** Betterer run. This PR skips it when we're already inside a git repository, and fixes the retry loop so init errors are actually surfaced.

### Why

`init()` calls `_findGitRoot()` first, which throws unless a `.git` already exists — so by the time `_init()` runs, the repository is guaranteed to be initialized and the `git init` is redundant.

It's also **harmful in git worktree setups**. When Betterer runs inside a linked worktree (`<worktree>/.git` is a gitfile pointing into a shared common git dir), the redundant `git init` reinitializes against the **common** git dir and rewrites shared config — flipping `core.bare` and breaking every worktree on the repo.

This is reliably reproducible with the popular "bare clone + worktree" layout:

```sh
git clone --bare <url> repo.git        # core.bare = true
git -C repo.git worktree add ../wt main
# core.bare is still true here...
git -C ../wt init                      # Reinitialized existing Git repository
# core.bare in repo.git/config is now FALSE — every worktree is broken
```

Separately, the retry loop could never rethrow:

```ts
for (let i = 0; i < retries; i++) {
  try { await git.init(); }
  catch (error) { if (i >= retries) throw error; }  // i maxes at retries-1, so never true
}
```

so any `git init` failure (e.g. parallel workers colliding on the config lock — `error: could not lock config file …/config: File exists`) was silently swallowed.

### Changes

- `packages/betterer/src/fs/git.ts`: guard `git.init()` behind `git.checkIsRepo()` so an already-initialized repo is never reinitialized; fix the retry condition (`i === retries - 1`) and return on success.

```ts
private async _init(git: SimpleGit): Promise<void> {
  if (await git.checkIsRepo()) {
    return;
  }

  const retries = 3;
  for (let i = 0; i < retries; i++) {
    try {
      await git.init();
      return;
    } catch (error) {
      if (i === retries - 1) {
        throw error;
      }
    }
  }
}
```

- `test/worktree.spec.ts`: new regression test that builds a bare-repo + linked-worktree layout, runs Betterer inside the worktree, and asserts the shared common-dir `core.bare` is untouched. It fails against the current code (`core.bare` flips `true → false`) and passes with this change.

### Behavior impact

- **Normal (already-initialized) repos:** `git init` is no longer invoked — previously a no-op, now skipped entirely. No functional change to Betterer's results.
- **Worktree / shared-common-dir repos:** the shared config is no longer mutated, so `core.bare` can't be flipped.
- **Genuinely uninitialized directory:** unchanged — `init()` still runs (and now correctly throws after exhausting retries instead of swallowing the error). Note that `_findGitRoot()` already throws before reaching here unless a `.git` exists, so this path is effectively unreachable today; the guard is defensive and self-documenting.

### Note on `v6`

This targets the `master` (5.x) line, where the bug lives. The `v6`/`nx` rewrite already removed this code path — `BettererGitΩ` no longer calls `git init` and version control is only created in precommit mode — so there's nothing to port forward. This is purely a 5.x fix.

Possibly related: #1129 (same `_findGitRoot`/init area).
